### PR TITLE
fixed candies path lookup + deleted force candies compatibility check flag

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -27,11 +27,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/src/main/java/org/jsweet/JSweetCommandLineLauncher.java
+++ b/src/main/java/org/jsweet/JSweetCommandLineLauncher.java
@@ -57,8 +57,8 @@ public class JSweetCommandLineLauncher {
 	 */
 	public static void main(String[] args) {
 		try {
-			JSAP jsapSpec;
-			JSAPResult jsapArgs = parseArgs(jsapSpec = defineArgs(), args);
+			JSAP jsapSpec = defineArgs();
+			JSAPResult jsapArgs = parseArgs(jsapSpec, args);
 
 			if (!jsapArgs.success()) {
 				printUsage(jsapSpec);

--- a/src/main/java/org/jsweet/transpiler/JSweetTranspiler.java
+++ b/src/main/java/org/jsweet/transpiler/JSweetTranspiler.java
@@ -1177,14 +1177,6 @@ public class JSweetTranspiler {
 	}
 
 	/**
-	 * Sets the transpiler to raise an error when not compatible with a given
-	 * candy version.
-	 */
-	public void setForceCandiesCompatibility(boolean force) {
-		candiesProcessor.setForceCandiesCompatibility(force);
-	}
-
-	/**
 	 * Gets the module kind when transpiling to code using JavaScript modules.
 	 */
 	public ModuleKind getModuleKind() {

--- a/src/main/java/org/jsweet/transpiler/candies/CandiesMerger.java
+++ b/src/main/java/org/jsweet/transpiler/candies/CandiesMerger.java
@@ -62,11 +62,10 @@ public class CandiesMerger {
 	private static final List<String> BUILTIN_MIXINS = asList(UTIL_PACKAGE + "." + STRING_TYPES_INTERFACE_NAME);
 
 	private File targetDir;
-	private List<String> candyClassPathEntries;
 	private URLClassLoader candyClassLoader;
 	private ClassPool classPool;
 
-	private Map<String, ClassPool> candyClassPools;
+	private Map<File, ClassPool> candyClassPools;
 
 	/**
 	 * Overrides the default behavior so that it never uses any other class
@@ -98,15 +97,14 @@ public class CandiesMerger {
 	 * Creates a new candies merger that will merge the candies found in the
 	 * classpath and output the result to the given target directory.
 	 */
-	public CandiesMerger(File targetDir, List<String> candyClassPathEntries) {
+	public CandiesMerger(File targetDir, List<File> candyClassPathEntries) {
 		logger.debug("new candies merger");
 		logger.debug("targetDir: " + targetDir.getAbsolutePath());
 		logger.debug("candies classpath entries: " + candyClassPathEntries);
 		this.targetDir = targetDir;
-		this.candyClassPathEntries = candyClassPathEntries;
-		this.candyClassLoader = new CandyClassLoader(candyClassPathEntries.stream().map((entry) -> {
+		this.candyClassLoader = new CandyClassLoader(candyClassPathEntries.stream().map(entry -> {
 			try {
-				return new File(entry).toURI().toURL();
+				return entry.toURI().toURL();
 			} catch (Exception e) {
 				logger.error("wrong class path entry " + entry, e);
 				return null;
@@ -116,12 +114,12 @@ public class CandiesMerger {
 
 		this.candyClassPools = new HashMap<>();
 		this.classPool = new ClassPool(ClassPool.getDefault());
-		for (String entry : candyClassPathEntries) {
+		for (File entry : candyClassPathEntries) {
 			try {
-				this.classPool.appendClassPath(entry);
+				this.classPool.appendClassPath(entry.getAbsolutePath());
 
 				ClassPool candyClassPool = new ClassPool();
-				candyClassPool.appendClassPath(entry);
+				candyClassPool.appendClassPath(entry.getAbsolutePath());
 				candyClassPools.put(entry, candyClassPool);
 			} catch (Exception e) {
 				logger.error("wrong class path entry " + entry, e);
@@ -331,12 +329,4 @@ public class CandiesMerger {
 		if (verbose)
 			logger.debug("merged " + memberCount + " member(s) and ignored " + ignoredDuplicates + " duplicates");
 	}
-
-	/**
-	 * Gets the classpath entries that correspond to JSweet candies.
-	 */
-	public List<String> getCandyClassPathEntries() {
-		return candyClassPathEntries;
-	}
-
 }


### PR DESCRIPTION
Gradle stores its maven dependencies in a different tree structure than classic maven, previous implementations didn't work with this.