### PR TITLE
squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList"

### DIFF
--- a/src/main/java/org/jsweet/transpiler/util/DirectedGraph.java
+++ b/src/main/java/org/jsweet/transpiler/util/DirectedGraph.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 /**
@@ -347,10 +348,10 @@ public class DirectedGraph<T> implements Collection<T> {
 	public static class Node<T> {
 		private DirectedGraph<T> graph;
 		public final T element;
-		public final HashSet<Edge<T>> inEdges;
-		public final HashSet<Edge<T>> usedInEdges;
-		public final HashSet<Edge<T>> outEdges;
-		public final HashSet<Edge<T>> usedOutEdges;
+		public final Set<Edge<T>> inEdges;
+		public final Set<Edge<T>> usedInEdges;
+		public final Set<Edge<T>> outEdges;
+		public final Set<Edge<T>> usedOutEdges;
 
 		public Node(DirectedGraph<T> graph, T element) {
 			this.graph = graph;

--- a/src/main/java/org/jsweet/transpiler/util/Util.java
+++ b/src/main/java/org/jsweet/transpiler/util/Util.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
@@ -107,7 +106,7 @@ public class Util {
 	 * @param files
 	 *            the list to add the files matching the extension
 	 */
-	public static void addFiles(String extension, File file, LinkedList<File> files) {
+	public static void addFiles(String extension, File file, List<File> files) {
 		if (file.isDirectory()) {
 			for (File f : file.listFiles()) {
 				addFiles(extension, f, files);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1319
Please let me know if you have any questions.
George Kankava