### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/src/main/java/org/jsweet/transpiler/OverloadScanner.java
+++ b/src/main/java/org/jsweet/transpiler/OverloadScanner.java
@@ -160,7 +160,7 @@ public class OverloadScanner extends TreeScanner {
 		if (!(e instanceof ClassSymbol)) {
 			return;
 		}
-		Overload overload = context.getOverload(((ClassSymbol) e), methodDecl.name.toString());
+		Overload overload = context.getOverload((ClassSymbol) e, methodDecl.name.toString());
 		if (overload != null && overload.methods.size() > 1 && overload.isValid) {
 			if (!methodDecl.sym.equals(overload.coreMethod)) {
 				if (methodDecl.body != null && methodDecl.body.stats.size() == 1) {

--- a/src/main/java/org/jsweet/transpiler/candies/CandiesProcessor.java
+++ b/src/main/java/org/jsweet/transpiler/candies/CandiesProcessor.java
@@ -92,7 +92,7 @@ public class CandiesProcessor {
 	 *            the classpath where the processor will seek for JSweet candies
 	 */
 	public CandiesProcessor(File workingDir, String classPath) {
-		this.classPath = (classPath == null ? System.getProperty("java.class.path") : classPath);
+		this.classPath = classPath == null ? System.getProperty("java.class.path") : classPath;
 		String[] cp = this.classPath.split(File.pathSeparator);
 		int[] indices = new int[0];
 		for (int i = 0; i < cp.length; i++) {

--- a/src/main/java/org/jsweet/transpiler/typescript/Java2TypeScriptAdapter.java
+++ b/src/main/java/org/jsweet/transpiler/typescript/Java2TypeScriptAdapter.java
@@ -565,7 +565,7 @@ public class Java2TypeScriptAdapter extends AbstractPrinterAdapter {
 			return getPrinter();
 		}
 		if (typeTree instanceof JCTypeApply) {
-			JCTypeApply typeApply = ((JCTypeApply) typeTree);
+			JCTypeApply typeApply = (JCTypeApply) typeTree;
 			String typeName = typeApply.clazz.toString();
 			if (typeFullName.startsWith(TUPLE_CLASSES_PACKAGE + ".")) {
 				getPrinter().print("[");

--- a/src/main/java/org/jsweet/transpiler/typescript/Java2TypeScriptTranslator.java
+++ b/src/main/java/org/jsweet/transpiler/typescript/Java2TypeScriptTranslator.java
@@ -1331,7 +1331,7 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 
 	@Override
 	public void visitNewClass(JCNewClass newClass) {
-		ClassSymbol clazz = ((ClassSymbol) newClass.clazz.type.tsym);
+		ClassSymbol clazz = (ClassSymbol) newClass.clazz.type.tsym;
 		if (clazz.name.toString().endsWith(JSweetConfig.GLOBALS_CLASS_NAME)) {
 			report(newClass, JSweetProblem.GLOBAL_CANNOT_BE_INSTANTIATED);
 			return;

--- a/src/main/java/org/jsweet/transpiler/util/AbstractPrinterAdapter.java
+++ b/src/main/java/org/jsweet/transpiler/util/AbstractPrinterAdapter.java
@@ -150,7 +150,7 @@ public abstract class AbstractPrinterAdapter {
 	}
 
 	public boolean matchesField(JCFieldAccess fieldAccess, Class<?> targetClass, String fieldName) {
-		return (fieldName.equals(fieldAccess.name.toString()) && targetClass.getName().equals(fieldAccess.selected.type.getModelType().toString()));
+		return fieldName.equals(fieldAccess.name.toString()) && targetClass.getName().equals(fieldAccess.selected.type.getModelType().toString());
 	}
 
 	public JCFieldAccess matchesField(JCAssign assignment, Class<?> targetClass, String fieldName) {
@@ -195,7 +195,7 @@ public abstract class AbstractPrinterAdapter {
 
 	public AbstractTreePrinter substituteAndPrintType(JCTree typeTree, boolean arrayComponent) {
 		if (typeTree instanceof JCTypeApply) {
-			JCTypeApply typeApply = ((JCTypeApply) typeTree);
+			JCTypeApply typeApply = (JCTypeApply) typeTree;
 			substituteAndPrintType(typeApply.clazz, arrayComponent);
 			if (!typeApply.arguments.isEmpty()) {
 				getPrinter().print("<");

--- a/src/main/java/org/jsweet/transpiler/util/Util.java
+++ b/src/main/java/org/jsweet/transpiler/util/Util.java
@@ -94,7 +94,7 @@ public class Util {
 	 */
 	public static boolean isSourceType(ClassSymbol clazz) {
 		// hack to know if it is a source file or a class file
-		return (clazz.sourcefile != null && clazz.sourcefile.getClass().getName().equals("com.sun.tools.javac.file.RegularFileObject"));
+		return clazz.sourcefile != null && clazz.sourcefile.getClass().getName().equals("com.sun.tools.javac.file.RegularFileObject");
 	}
 
 	/**
@@ -218,7 +218,7 @@ public class Util {
 	 * Tells if the given type is a Java interface.
 	 */
 	public static boolean isInterface(TypeSymbol typeSymbol) {
-		return (typeSymbol.type.isInterface() || Util.hasAnnotationType(typeSymbol, JSweetConfig.ANNOTATION_INTERFACE));
+		return typeSymbol.type.isInterface() || Util.hasAnnotationType(typeSymbol, JSweetConfig.ANNOTATION_INTERFACE);
 	}
 
 	private static void putVar(Map<String, VarSymbol> vars, VarSymbol varSymbol) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AUselessParenthesesCheck
Please let me know if you have any questions.
George Kankava