### PR TITLE
squid:CommentedOutCodeLine - Sections of code should not be "commented out"

### DIFF
--- a/src/main/java/org/jsweet/JSweetConfig.java
+++ b/src/main/java/org/jsweet/JSweetConfig.java
@@ -260,20 +260,17 @@ public abstract class JSweetConfig {
 		// note TS keywords are removed from that list
 		JAVA_KEYWORDS.add("abstract");
 		JAVA_KEYWORDS.add("assert");
-		// JAVA_KEYWORDS.add("boolean");
 		JAVA_KEYWORDS.add("break");
 		JAVA_KEYWORDS.add("byte");
 		JAVA_KEYWORDS.add("case");
 		JAVA_KEYWORDS.add("catch");
 		JAVA_KEYWORDS.add("char");
-		// JAVA_KEYWORDS.add("class");
 		JAVA_KEYWORDS.add("const");
 		JAVA_KEYWORDS.add("continue");
 		JAVA_KEYWORDS.add("default");
 		JAVA_KEYWORDS.add("do");
 		JAVA_KEYWORDS.add("double");
 		JAVA_KEYWORDS.add("else");
-		// JAVA_KEYWORDS.add("enum");
 		JAVA_KEYWORDS.add("extends");
 		JAVA_KEYWORDS.add("final");
 		JAVA_KEYWORDS.add("finally");
@@ -281,11 +278,9 @@ public abstract class JSweetConfig {
 		JAVA_KEYWORDS.add("for");
 		JAVA_KEYWORDS.add("goto");
 		JAVA_KEYWORDS.add("if");
-		// JAVA_KEYWORDS.add("implements");
 		JAVA_KEYWORDS.add("import");
 		JAVA_KEYWORDS.add("instanceof");
 		JAVA_KEYWORDS.add("int");
-		// JAVA_KEYWORDS.add("interface");
 		JAVA_KEYWORDS.add("long");
 		JAVA_KEYWORDS.add("native");
 		JAVA_KEYWORDS.add("new");
@@ -305,7 +300,6 @@ public abstract class JSweetConfig {
 		JAVA_KEYWORDS.add("throws");
 		JAVA_KEYWORDS.add("transient");
 		JAVA_KEYWORDS.add("try");
-		// JAVA_KEYWORDS.add("void");
 		JAVA_KEYWORDS.add("volatile");
 		JAVA_KEYWORDS.add("while");
 

--- a/src/main/java/org/jsweet/transpiler/JSweetTranspiler.java
+++ b/src/main/java/org/jsweet/transpiler/JSweetTranspiler.java
@@ -307,8 +307,6 @@ public class JSweetTranspiler implements JSweetOptions {
 		Writer w = new StringWriter() {
 			@Override
 			public void write(String str) {
-				// TranspilationHandler.OUTPUT_LOGGER.error(getBuffer());
-				// getBuffer().delete(0, getBuffer().length());
 			}
 
 		};
@@ -947,7 +945,6 @@ public class JSweetTranspiler implements JSweetOptions {
 			args.add("--declaration");
 		}
 		args.addAll(asList("--rootDir", tsOutputDir.getAbsolutePath()));
-		// args.addAll(asList("--sourceRoot", tsOutputDir.toString()));
 
 		if (jsOutputDir != null) {
 			args.addAll(asList("--outDir", jsOutputDir.getAbsolutePath()));
@@ -1012,12 +1009,6 @@ public class JSweetTranspiler implements JSweetOptions {
 				}
 			} , args.toArray(new String[0]));
 
-			// tsCompilationProcess.waitFor();
-			// if (tsCompilationProcess != null &&
-			// tsCompilationProcess.exitValue() == 1) {
-			// transpilationHandler.report(JSweetProblem.TSC_CANNOT_START, null,
-			// JSweetProblem.TSC_CANNOT_START.getMessage());
-			// }
 		} catch (Exception e) {
 			e.printStackTrace();
 		}

--- a/src/main/java/org/jsweet/transpiler/TypeChecker.java
+++ b/src/main/java/org/jsweet/transpiler/TypeChecker.java
@@ -72,7 +72,6 @@ public class TypeChecker {
 	public static final Set<String> FORBIDDEN_JDK_FUNCTIONAL_METHODS = new HashSet<String>();
 
 	static {
-		// AUTHORIZED_ACCESSED_TYPES.add(String.class.getName());
 
 		AUTHORIZED_DECLARED_TYPES.add(String.class.getName());
 		AUTHORIZED_DECLARED_TYPES.add(Object.class.getName());

--- a/src/main/java/org/jsweet/transpiler/typescript/Java2TypeScriptAdapter.java
+++ b/src/main/java/org/jsweet/transpiler/typescript/Java2TypeScriptAdapter.java
@@ -152,10 +152,6 @@ public class Java2TypeScriptAdapter extends AbstractPrinterAdapter {
 						return null;
 					}
 				}
-				// MethodSymbol staticMethSymbol =
-				// Util.findMethodDeclarationInType(getPrinter().getContext().types,
-				// fa.selected.type.tsym, "" + fa.name, null);
-				// String methodName = Util.getActualName(staticMethSymbol);
 				return StringUtils.isBlank(name) ? null : name + "." + getIdentifier(methodName);
 			} else {
 				return null;
@@ -204,10 +200,6 @@ public class Java2TypeScriptAdapter extends AbstractPrinterAdapter {
 			targetMethodName = invocation.getMethodSelect().toString();
 		}
 
-		// System.out.println(invocation+" ===> "+fieldAccess+" :
-		// targetClassName="+targetClassName+"
-		// targetMethodName="+targetMethodName+
-		// " ownerClassName="+ownerClassName);
 
 		if (targetType != null && targetType.getKind() == ElementKind.ENUM) {
 			// TODO: enum type simple name will not be valid when uses as fully
@@ -541,10 +533,6 @@ public class Java2TypeScriptAdapter extends AbstractPrinterAdapter {
 
 	@Override
 	public AbstractTreePrinter substituteAndPrintType(JCTree typeTree, boolean arrayComponent) {
-		// String fullName=typeTree.type.getModelType().toString();
-		// if(fullName.startsWith(Console.class.getPackage().getName())) {
-		// return "any";
-		// }
 		if (Util.hasAnnotationType(typeTree.type.tsym, ANNOTATION_ERASED)) {
 			return getPrinter().print("any");
 		}

--- a/src/main/java/org/jsweet/transpiler/typescript/Java2TypeScriptTranslator.java
+++ b/src/main/java/org/jsweet/transpiler/typescript/Java2TypeScriptTranslator.java
@@ -314,7 +314,6 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 								"/" + targetRootPackageName);
 						if (pathToReachRootPackage == null) {
 							pathToReachRootPackage = ".";
-							// continue;
 						}
 						File moduleFile = new File(new File(pathToReachRootPackage), JSweetConfig.MODULE_FILE_NAME);
 						useModule((PackageSymbol) qualified.sym.getEnclosingElement(), importDecl, targetRootPackageName,
@@ -1088,10 +1087,6 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 			if (compilationUnit.packge.getQualifiedName().toString().startsWith(name)) {
 				return null;
 			}
-			// MethodSymbol staticMethSymbol =
-			// Util.findMethodDeclarationInType(printer.context.types,
-			// fa.selected.type.tsym, "" + fa.name, null);
-			// String methodName = Util.getActualName(staticMethSymbol);
 			return name;
 		}
 
@@ -1158,7 +1153,6 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 							report(inv, JSweetProblem.HIDDEN_INVOCATION, methSym.getSimpleName());
 						}
 					}
-					// staticImported = true;
 					if (JSweetConfig.TS_STRICT_MODE_KEYWORDS.contains(methName.toLowerCase())) {
 						// if method is a reserved TS keyword, no "static
 						// import" possible, fully qualified mode
@@ -1304,8 +1298,7 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 		if (!getAdapter().substituteIdentifier(ident)) {
 			// add this of class name if ident is a field
 			if (ident.sym instanceof VarSymbol && !ident.sym.name.equals(context.names._this) && !ident.sym.name.equals(context.names._super)) {
-				VarSymbol varSym = (VarSymbol) ident.sym; // findFieldDeclaration(currentClass,
-				// ident.name);
+				VarSymbol varSym = (VarSymbol) ident.sym;
 				if (varSym != null) {
 					if (varSym.owner instanceof ClassSymbol) {
 						if (!varSym.getModifiers().contains(Modifier.STATIC)) {
@@ -1404,11 +1397,6 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 				println().endIndent().printIndent().print("}");
 			} else {
 
-				// ((target : DataStruct3) => {
-				// target['i'] = 1;
-				// target['s2'] = "";
-				// return target
-				// })(new DataStruct3());
 
 				print("((target:").print(newClass.clazz).print(") => {").println().startIndent();
 				for (JCTree m : newClass.def.getMembers()) {
@@ -1615,19 +1603,6 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 		if (newArray.elemtype != null) {
 			typeChecker.checkType(newArray, null, newArray.elemtype);
 		}
-		// if (newArray.elemtype != null) {
-		// print("new ");
-		// newArray.elemtype.accept(this);
-		// }
-		// if (newArray.dims.isEmpty()) {
-		// print("[]");
-		// } else {
-		// for (JCExpression dim : newArray.dims) {
-		// print("[");
-		// dim.accept(this);
-		// print("]");
-		// }
-		// }
 		print("[");
 		if (newArray.elems != null) {
 			printArgList(newArray.elems);

--- a/src/main/java/org/jsweet/transpiler/util/AbstractTreePrinter.java
+++ b/src/main/java/org/jsweet/transpiler/util/AbstractTreePrinter.java
@@ -166,25 +166,6 @@ public abstract class AbstractTreePrinter extends AbstractTreeScanner {
 			if (currentLine != line) {
 				logger.warn("cannot adjust line for: " + tree.getClass() + " at line " + line);
 			}
-			// adjusting columns... (TODO: does not work)
-			// int column =
-			// compilationUnit.lineMap.getColumnNumber(stack.peek().pos);
-			// while (currentColumn < column) {
-			// // System.out.println("adding a column on "+tree.getClass());
-			// out.append(" ");
-			// currentColumn++;
-			// }
-			// while (currentColumn > column
-			// && ((currentColumn == 1 && out.charAt(out.length() - 1) == ' ')
-			// || (currentColumn > 1 && out.charAt(out.length() - 2) == ' '))) {
-			// out.deleteCharAt(out.length() - 1);
-			// currentColumn--;
-			// }
-			// if (currentColumn != column) {
-			// System.out.println("cannot adjust column for: " + tree.getClass()
-			// + " at position " + line + ", " + column + " - " + (currentColumn
-			// - column));
-			// }
 		}
 		positionStack.push(new Position(getCurrentPosition(), currentLine, currentColumn));
 	}

--- a/src/main/java/org/jsweet/transpiler/util/JavaCompilationEnvironment.java
+++ b/src/main/java/org/jsweet/transpiler/util/JavaCompilationEnvironment.java
@@ -61,10 +61,6 @@ public class JavaCompilationEnvironment {
 		options.put(Option.XLINT, "path");
 		context.put(Log.outKey, new PrintWriter(System.out));
 
-		// options.put(Option.XLINT_CUSTOM.text + "-" +
-		// LintCategory.OPTIONS.option, "true");
-		// options.remove(Option.XLINT_CUSTOM.text +
-		// LintCategory.OPTIONS.option);
 
 		options.put(Option.XLINT_CUSTOM.text + "-" + LintCategory.OVERRIDES.option, "true");
 

--- a/src/main/java/org/jsweet/transpiler/util/Util.java
+++ b/src/main/java/org/jsweet/transpiler/util/Util.java
@@ -202,9 +202,6 @@ public class Util {
 					continue;
 				}
 				return true;
-				// if (method.body != null) {
-				// return true;
-				// }
 			} else if (member instanceof JCVariableDecl) {
 				if (((JCVariableDecl) member).mods.getFlags().contains(Modifier.STATIC)) {
 					return true;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:CommentedOutCodeLine - Sections of code should not be "commented out".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3ACommentedOutCodeLine
Please let me know if you have any questions.
George Kankava