### PR TITLE
Transpiler interface to perform code migration

### DIFF
--- a/src/main/java/org/jsweet/transpiler/JSweetProblem.java
+++ b/src/main/java/org/jsweet/transpiler/JSweetProblem.java
@@ -266,6 +266,10 @@ public enum JSweetProblem {
 	 * Raised when a class tries to extend a Globals class.
 	 */
 	GLOBALS_CLASS_CANNOT_BE_SUBCLASSED(Severity.ERROR),
+    /**
+	 * Raised when trying to access this from scope it isn't defined.
+	 */
+    CANNOT_ACCESS_THIS(Severity.ERROR),
 	/**
 	 * Raised when invoking a static method on this (this is allowed in Java,
 	 * but not in JSweet).
@@ -418,6 +422,8 @@ public enum JSweetProblem {
 			return String.format("globals classes cannot extend any class", params);
 		case GLOBALS_CLASS_CANNOT_BE_SUBCLASSED:
 			return String.format("globals classes cannot be subclassed", params);
+        case CANNOT_ACCESS_THIS:
+			return String.format("'this' isn't defined in scope of %s", params);
 		case CANNOT_ACCESS_STATIC_MEMBER_ON_THIS:
 			return String.format("member '%s' is static and cannot be accessed on 'this'", params);
 		case UNTYPED_OBJECT_ODD_PARAMETER_COUNT:

--- a/src/main/java/org/jsweet/transpiler/JSweetTranspiler.java
+++ b/src/main/java/org/jsweet/transpiler/JSweetTranspiler.java
@@ -1549,27 +1549,17 @@ public class JSweetTranspiler implements JSweetOptions {
 		jsLibFiles.clear();
 	}
 
-    public static class TranspiledPartsPrinter extends Pretty {
-
-        private final JSweetTranspiler transpiler;
-
-        public TranspiledPartsPrinter(Writer writer, JSweetTranspiler transpiler) {
-            super(writer, true);
-            this.transpiler = transpiler;
-        }
-
-        public String transpile(JCTree tree, ErrorCountTranspilationHandler handler, String name) throws IOException {
-            Java2TypeScriptTranslator translator = new Java2TypeScriptTranslator(
-                handler,
-                transpiler.context,
-                null,
-                false
-            );
-            translator.enterScope();
-            translator.scan(tree);
-            translator.exitScope();
-            String tsCode = translator.getResult();
-            return transpiler.tspart2js(tsCode, handler, name);
-        }
+    public String transpile(JCTree tree, ErrorCountTranspilationHandler handler, String name) throws IOException {
+        Java2TypeScriptTranslator translator = new Java2TypeScriptTranslator(
+            handler,
+            context,
+            null,
+            false
+        );
+        translator.enterScope();
+        translator.scan(tree);
+        translator.exitScope();
+        String tsCode = translator.getResult();
+        return tspart2js(tsCode, handler, name);
     }
 }

--- a/src/main/java/org/jsweet/transpiler/JSweetTranspiler.java
+++ b/src/main/java/org/jsweet/transpiler/JSweetTranspiler.java
@@ -310,16 +310,28 @@ public class JSweetTranspiler implements JSweetOptions {
 		log.dumpOnError = false;
 		log.emitWarnings = false;
 
-		Writer w = new StringWriter() {
+		Writer errorWriter = new StringWriter() {
 			@Override
 			public void write(String str) {
-				// TranspilationHandler.OUTPUT_LOGGER.error(getBuffer());
-				// getBuffer().delete(0, getBuffer().length());
+                logger.error(str);
 			}
-
+		};
+		Writer warningWriter = new StringWriter() {
+			@Override
+			public void write(String str) {
+                logger.warn(str);
+			}
+		};
+		Writer messageWriter = new StringWriter() {
+			@Override
+			public void write(String str) {
+                logger.trace(str);
+			}
 		};
 
-		log.setWriter(WriterKind.ERROR, new PrintWriter(w));
+		log.setWriter(WriterKind.ERROR, new PrintWriter(errorWriter));
+		log.setWriter(WriterKind.WARNING, new PrintWriter(warningWriter));
+		log.setWriter(WriterKind.NOTICE, new PrintWriter(messageWriter));
 		log.setDiagnosticFormatter(new BasicDiagnosticFormatter(JavacMessages.instance(context)) {
 			@Override
 			public String format(JCDiagnostic diagnostic, Locale locale) {
@@ -330,12 +342,13 @@ public class JSweetTranspiler implements JSweetOptions {
 					}
 				}
 				if (diagnostic.getSource() != null) {
-					return diagnostic.getMessage(locale) + " at " + diagnostic.getSource().getName() + "(" + diagnostic.getLineNumber() + ")";
+					return diagnostic.getMessage(locale) + " atata " + diagnostic.getSource().getName() + "(" + diagnostic.getLineNumber() + ")";
 				} else {
 					return diagnostic.getMessage(locale);
 				}
 			}
 		});
+        compiler.log = log;
 
 		if (encoding != null) {
 			compiler.encoding = encoding;

--- a/src/main/java/org/jsweet/transpiler/JSweetTranspiler.java
+++ b/src/main/java/org/jsweet/transpiler/JSweetTranspiler.java
@@ -301,34 +301,36 @@ public class JSweetTranspiler implements JSweetOptions {
 
 		compiler = JavaCompiler.instance(context);
 		compiler.attrParseOnly = true;
-		compiler.verbose = false;
+		compiler.verbose = true;
 		compiler.genEndPos = true;
 		compiler.keepComments = true;
-
 		log = Log.instance(context);
-
 		log.dumpOnError = false;
-		log.emitWarnings = false;
-
+		log.emitWarnings = true;
 		Writer errorWriter = new StringWriter() {
 			@Override
 			public void write(String str) {
-                logger.error(str);
+                if (str != null && !str.isEmpty()) {
+                    logger.error(str);
+                }
 			}
 		};
 		Writer warningWriter = new StringWriter() {
 			@Override
 			public void write(String str) {
-                logger.warn(str);
+                if (str != null && !str.isEmpty()) {
+                    logger.debug(str);
+                }
 			}
 		};
 		Writer messageWriter = new StringWriter() {
 			@Override
 			public void write(String str) {
-                logger.trace(str);
+                if (str != null && !str.isEmpty()) {
+                    logger.trace(str);
+                }
 			}
 		};
-
 		log.setWriter(WriterKind.ERROR, new PrintWriter(errorWriter));
 		log.setWriter(WriterKind.WARNING, new PrintWriter(warningWriter));
 		log.setWriter(WriterKind.NOTICE, new PrintWriter(messageWriter));
@@ -342,7 +344,7 @@ public class JSweetTranspiler implements JSweetOptions {
 					}
 				}
 				if (diagnostic.getSource() != null) {
-					return diagnostic.getMessage(locale) + " atata " + diagnostic.getSource().getName() + "(" + diagnostic.getLineNumber() + ")";
+					return diagnostic.getMessage(locale) + " at " + diagnostic.getSource().getName() + "(" + diagnostic.getLineNumber() + ")";
 				} else {
 					return diagnostic.getMessage(locale);
 				}

--- a/src/main/java/org/jsweet/transpiler/typescript/Java2TypeScriptAdapter.java
+++ b/src/main/java/org/jsweet/transpiler/typescript/Java2TypeScriptAdapter.java
@@ -1164,6 +1164,9 @@ public class Java2TypeScriptAdapter extends AbstractPrinterAdapter {
 			getPrinter().print("\"");
 			return true;
 		}
+        if (identifier.type == null) {
+            return super.substituteIdentifier(identifier);           
+        }
 		if (langTypesSimpleNames.contains(identifier.toString()) && langTypesMapping.containsKey(identifier.type.toString())) {
 			getPrinter().print(langTypesMapping.get(identifier.type.toString()));
 			return true;

--- a/src/main/java/org/jsweet/transpiler/util/AbstractTreePrinter.java
+++ b/src/main/java/org/jsweet/transpiler/util/AbstractTreePrinter.java
@@ -163,10 +163,12 @@ public abstract class AbstractTreePrinter extends AbstractTreeScanner {
 			// }
 		}
 		positionStack.push(new Position(getCurrentPosition(), currentLine, currentColumn));
-		sourceMap.addEntry(new Position(tree.pos, //
-				compilationUnit.lineMap.getLineNumber(tree.pos), //
-				compilationUnit.lineMap.getColumnNumber(tree.pos)), positionStack.peek());
-	}
+        if (compilationUnit != null) {
+            sourceMap.addEntry(new Position(tree.pos, //
+                    compilationUnit.lineMap.getLineNumber(tree.pos), //
+                    compilationUnit.lineMap.getColumnNumber(tree.pos)), positionStack.peek());
+        }
+    }
 
 	@Override
 	protected void onRollbacked(JCTree target) {

--- a/src/main/java/org/jsweet/transpiler/util/AbstractTreeScanner.java
+++ b/src/main/java/org/jsweet/transpiler/util/AbstractTreeScanner.java
@@ -54,20 +54,26 @@ public abstract class AbstractTreeScanner extends TreeScanner {
 		if (logHandler == null) {
 			System.err.println(problem.getMessage(params));
 		} else {
-			int s = tree.getStartPosition();
-			int e = tree.getEndPosition(diagnosticSource.getEndPosTable());
-			if (e == -1) {
-				e = s;
-			}
-			if (name != null) {
-				e += name.length();
-			}
-			logHandler.report(problem,
-					new SourcePosition(new File(compilationUnit.sourcefile.getName()), tree, diagnosticSource.getLineNumber(s),
-							diagnosticSource.getColumnNumber(s, false), diagnosticSource.getLineNumber(e), diagnosticSource.getColumnNumber(e, false)),
-					problem.getMessage(params));
-		}
-	}
+            if(diagnosticSource == null) {
+                logHandler.report(problem,
+                    null,
+                    problem.getMessage(params));
+            } else {
+                int s = tree.getStartPosition();
+                int e = tree.getEndPosition(diagnosticSource.getEndPosTable());
+                if (e == -1) {
+                    e = s;
+                }
+                if (name != null) {
+                    e += name.length();
+                }
+                logHandler.report(problem,
+                        new SourcePosition(new File(compilationUnit.sourcefile.getName()), tree, diagnosticSource.getLineNumber(s),
+                                diagnosticSource.getColumnNumber(s, false), diagnosticSource.getLineNumber(e), diagnosticSource.getColumnNumber(e, false)),
+                        problem.getMessage(params));
+            }
+        }
+    }
 
 	protected Stack<JCTree> stack = new Stack<JCTree>();
 
@@ -158,7 +164,11 @@ public abstract class AbstractTreeScanner extends TreeScanner {
 	}
 
 	public JCTree getParent() {
-		return this.stack.get(this.stack.size() - 2);
+        if (this.stack.size() >= 2) {
+            return this.stack.get(this.stack.size() - 2);
+        } else {
+            return null;
+        }
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/test/java/org/jsweet/test/transpiler/MigrationTest.java
+++ b/src/test/java/org/jsweet/test/transpiler/MigrationTest.java
@@ -17,6 +17,7 @@
 package org.jsweet.test.transpiler;
 
 import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.Pretty;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -28,7 +29,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.jsweet.transpiler.JSweetTranspiler;
-import org.jsweet.transpiler.JSweetTranspiler.TranspiledPartsPrinter;
 import org.jsweet.transpiler.util.ConsoleTranspilationHandler;
 import org.jsweet.transpiler.util.ErrorCountTranspilationHandler;
 import org.junit.Assert;
@@ -57,7 +57,7 @@ public class MigrationTest extends AbstractTest {
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         Writer writer = new OutputStreamWriter(baos);
-        TranspiledPartsPrinter printer = new TranspiledPartsPrinter(writer, transpiler) {
+        Pretty printer = new Pretty(writer, true) {
 
             @Override
             public void visitMethodDef(JCTree.JCMethodDecl method) {
@@ -67,7 +67,7 @@ public class MigrationTest extends AbstractTest {
                     ErrorCountTranspilationHandler handler = new ErrorCountTranspilationHandler(new ConsoleTranspilationHandler());
                     String jsCode;
                     try {
-                        jsCode = transpile(method, handler, "part");
+                        jsCode = transpiler.transpile(method, handler, "part");
                     } catch (IOException ex) {
                         throw new UncheckedIOException(ex);
                     }

--- a/src/test/java/org/jsweet/test/transpiler/MigrationTest.java
+++ b/src/test/java/org/jsweet/test/transpiler/MigrationTest.java
@@ -53,8 +53,8 @@ public class MigrationTest extends AbstractTest {
         transpiler.initNode(handler);
         List<JCTree.JCCompilationUnit> units
             = transpiler.setupCompiler(Arrays.asList(input), handler);
-        Assert.assertEquals(1,units.size());
-        
+        Assert.assertEquals(1, units.size());
+
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         Writer writer = new OutputStreamWriter(baos);
         TranspiledPartsPrinter printer = new TranspiledPartsPrinter(writer, transpiler) {
@@ -92,7 +92,9 @@ public class MigrationTest extends AbstractTest {
         };
         units.get(0).accept(printer);
         writer.flush();
-        System.out.println(baos);
-
+        // System.out.println(baos); // prints resulting code
+        // verify that there are exactly two comments in the code
+        Assert.assertEquals(3, baos.toString().split("/\\*").length);
+        Assert.assertEquals(3, baos.toString().split("\\*/").length);
     }
 }

--- a/src/test/java/org/jsweet/test/transpiler/MigrationTest.java
+++ b/src/test/java/org/jsweet/test/transpiler/MigrationTest.java
@@ -1,0 +1,98 @@
+/* 
+ * JSweet - http://www.jsweet.org
+ * Copyright (C) 2015 CINCHEO SAS <renaud.pawlak@cincheo.fr>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jsweet.test.transpiler;
+
+import com.sun.tools.javac.tree.JCTree;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.jsweet.transpiler.JSweetTranspiler;
+import org.jsweet.transpiler.JSweetTranspiler.TranspiledPartsPrinter;
+import org.jsweet.transpiler.util.ConsoleTranspilationHandler;
+import org.jsweet.transpiler.util.ErrorCountTranspilationHandler;
+import org.junit.Assert;
+import org.junit.Test;
+import source.migration.QuickStart;
+
+public class MigrationTest extends AbstractTest {
+
+    @Test
+    public void test1() throws Exception {
+        File dir = Files.createTempDirectory("jsweet").toFile();
+        System.out.println("Transpile directory: " + dir);
+        ErrorCountTranspilationHandler handler = new ErrorCountTranspilationHandler(new ConsoleTranspilationHandler());
+        JSweetTranspiler transpiler = new JSweetTranspiler(
+            new File(dir, "wd"),
+            new File(dir, "ts"),
+            new File(dir, "js"),
+            new File(dir, "cjs"),
+            null
+        );
+        File input = new File(TEST_DIRECTORY_NAME + "/" + QuickStart.class.getName().replace(".", "/") + ".java");
+        transpiler.initNode(handler);
+        List<JCTree.JCCompilationUnit> units
+            = transpiler.setupCompiler(Arrays.asList(input), handler);
+        Assert.assertEquals(1,units.size());
+        
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Writer writer = new OutputStreamWriter(baos);
+        TranspiledPartsPrinter printer = new TranspiledPartsPrinter(writer, transpiler) {
+
+            @Override
+            public void visitMethodDef(JCTree.JCMethodDecl method) {
+                if ("<init>".equals(method.getName().toString()) || "<clinit>".equals(method.getName().toString())) {
+                    super.visitMethodDef(method);
+                } else {
+                    ErrorCountTranspilationHandler handler = new ErrorCountTranspilationHandler(new ConsoleTranspilationHandler());
+                    String jsCode;
+                    try {
+                        jsCode = transpile(method, handler, "part");
+                    } catch (IOException ex) {
+                        throw new UncheckedIOException(ex);
+                    }
+                    if (handler.getErrorCount() == 0) {
+                        try {
+                            print("\n/*\n");
+                            print(Arrays.stream(String.format(
+                                "java code:\n%s\njs code:\n%s\n",
+                                method,
+                                jsCode
+                            ).split("\n")).map(s -> " * " + s).collect(Collectors.joining("\n")));
+                            print("*/\n");
+                            print(method);
+                        } catch (IOException ex) {
+                            throw new UncheckedIOException(ex);
+                        }
+                    } else {
+                        super.visitMethodDef(method);
+                    }
+                }
+            }
+        };
+        units.get(0).accept(printer);
+        writer.flush();
+        System.out.println(baos);
+
+    }
+}

--- a/src/test/java/source/migration/QuickStart.java
+++ b/src/test/java/source/migration/QuickStart.java
@@ -1,0 +1,30 @@
+package source.migration;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class QuickStart {
+
+    public String concat(String[] array) {
+        String result = "";
+        for (int i = 0; i < array.length; ++i) {
+            result += array[i];
+        }
+        return result;
+    }
+
+    public void fail(String a, String b) {
+        System.out.println(concat(new String[]{a, b}));
+    }
+    
+    public Queue<String> wrap(String input){
+        LinkedList<String> list = new LinkedList<>();
+        list.add(input);
+        return list;
+    }
+
+    public static void main(String[] args) {
+        java.util.function.Function<Object, Object> function = o -> o;
+        System.out.println("Hi, random=" + function.apply(4));
+    }
+}


### PR DESCRIPTION
These changes can serve as a transpiler interface to perform code migration with custom rules. The concept is that there are the code that cannot be automatically transpiled to JavaScript, but small parts of this code can. The concrete logic for choosing parts to transpile and for interaction between Java code and transpiling code is highly application-dependent and should be implemented at application side. As an implementation tool there is `TranspiledPartsPrinter` class with `transpile` method defined. There is usage example is `MigrationTest` (test does formal code check too)