### PR TITLE
Fixed parsing of empty S.*.println

### DIFF
--- a/transpiler/src/main/java/org/jsweet/transpiler/extension/Java2TypeScriptAdapter.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/extension/Java2TypeScriptAdapter.java
@@ -343,11 +343,17 @@ public class Java2TypeScriptAdapter extends PrinterAdapter {
 		if ("println".equals(targetMethodName)) {
 			if (invocationElement.getTargetExpression() != null) {
 				if ("System.out".equals(invocationElement.getTargetExpression().toString())) {
-					print("console.info(").print(invocationElement.getArgument(0)).print(")");
+					PrinterAdapter print = print("console.info(");
+					if (invocationElement.getArgumentCount() > 0)
+						print.print(invocationElement.getArgument(0));
+					print.print(")");
 					return true;
 				}
 				if ("System.err".equals(invocationElement.getTargetExpression().toString())) {
-					print("console.error(").print(invocationElement.getArgument(0)).print(")");
+					PrinterAdapter print = print("console.error(");
+					if (invocationElement.getArgumentCount() > 0)
+						print.print(invocationElement.getArgument(0));
+					print.print(")");
 					return true;
 				}
 			}

--- a/transpiler/src/test/java/org/jsweet/test/transpiler/MigrationTest.java
+++ b/transpiler/src/test/java/org/jsweet/test/transpiler/MigrationTest.java
@@ -91,7 +91,7 @@ public class MigrationTest extends AbstractTest {
 		writer.flush();
 		// System.out.println(baos); // prints resulting code
 		// verify that there are exactly two comments in the code
-		Assert.assertEquals(3, baos.toString().split("/\\*").length);
-		Assert.assertEquals(3, baos.toString().split("\\*/").length);
+		Assert.assertEquals(4, baos.toString().split("/\\*").length);
+		Assert.assertEquals(4, baos.toString().split("\\*/").length);
 	}
 }

--- a/transpiler/src/test/java/source/migration/QuickStart.java
+++ b/transpiler/src/test/java/source/migration/QuickStart.java
@@ -13,6 +13,10 @@ public class QuickStart {
         return result;
     }
 
+    public void empty() {
+        System.out.println();
+    }
+
     public void fail(String a, String b) {
         System.out.println(concat(new String[]{a, b}));
     }


### PR DESCRIPTION
Related to https://github.com/cincheo/jsweet/issues/234

`System.out.println()` with empty parameter list threw an `java.lang.IndexOutOfBoundsException: Index: 0, Size: 0`