### PR TITLE
WIP: Added test for abstract class inheriting from interface

### DIFF
--- a/transpiler/src/test/java/org/jsweet/test/transpiler/StructuralTests.java
+++ b/transpiler/src/test/java/org/jsweet/test/transpiler/StructuralTests.java
@@ -146,7 +146,7 @@ public class StructuralTests extends AbstractTest {
 
 	@Test
 	public void testInheritance() {
-		eval((logHandler, r) -> {
+		eval((logHandler, r) -> { // TODO
 			assertEquals("There should be no errors", 0, logHandler.reportedProblems.size());
 			assertEquals(true, r.<Boolean> get("X"));
 			assertEquals(true, r.<Boolean> get("Y"));

--- a/transpiler/src/test/java/source/structural/Inheritance.java
+++ b/transpiler/src/test/java/source/structural/Inheritance.java
@@ -23,6 +23,8 @@ import def.js.Array;
 import jsweet.lang.Interface;
 import def.js.JSON;
 
+import java.util.Iterator;
+
 class AloneInTheDarkClass extends def.js.Object {
 	public AloneInTheDarkClass() {
 		// super() call shouldn't be generated
@@ -134,4 +136,9 @@ class SomeShape implements Shape {
 		return null;
 	}
 
+}
+
+abstract class AbstractIterator<T> implements Iterator<T> {
+	@Override
+	public final T next() { return null; }
 }


### PR DESCRIPTION
Related to https://github.com/cincheo/jsweet/issues/234

@renaudpawlak, please help out, the error messages aren't very helpful for me.

```
INFO  AbstractTest:106 - *** test suite initialization ***
INFO  AbstractTest:108 - *** create transpiler ***
INFO  JSweetTranspiler:262 - no configuration file found
INFO  JSweetTranspiler:302 - creating transpiler version 2.0.0-SNAPSHOT (build date: 2017-03-30 08:47:05)
INFO  JSweetTranspiler:304 - curent dir: /media/papus/TI31436700A/_Projects/jsweet/transpiler/.
INFO  JSweetTranspiler:305 - tsOut: tempOut - /media/papus/TI31436700A/_Projects/jsweet/transpiler/tempOut
INFO  JSweetTranspiler:306 - jsOut: null
INFO  JSweetTranspiler:307 - candyJsOut: .jsweet/candies/js
INFO  JSweetTranspiler:308 - factory: org.jsweet.transpiler.JSweetFactory@42607a4f
INFO  CandyProcessor:113 - candies processor classpath: /home/papus/.local/share/JetBrains/Toolbox/apps/IDEA-C/ch-0/171.3780.107/lib/idea_rt.jar:/home/papus/.local/share/JetBrains/Toolbox/apps/IDEA-C/ch-0/171.3780.107/plugins/junit/lib/junit-rt.jar:/usr/lib/jvm/java-8-oracle/jre/lib/charsets.jar:/usr/lib/jvm/java-8-oracle/jre/lib/deploy.jar:/usr/lib/jvm/java-8-oracle/jre/lib/ext/cldrdata.jar:/usr/lib/jvm/java-8-oracle/jre/lib/ext/dnsns.jar:/usr/lib/jvm/java-8-oracle/jre/lib/ext/jaccess.jar:/usr/lib/jvm/java-8-oracle/jre/lib/ext/jfxrt.jar:/usr/lib/jvm/java-8-oracle/jre/lib/ext/localedata.jar:/usr/lib/jvm/java-8-oracle/jre/lib/ext/nashorn.jar:/usr/lib/jvm/java-8-oracle/jre/lib/ext/sunec.jar:/usr/lib/jvm/java-8-oracle/jre/lib/ext/sunjce_provider.jar:/usr/lib/jvm/java-8-oracle/jre/lib/ext/sunpkcs11.jar:/usr/lib/jvm/java-8-oracle/jre/lib/ext/zipfs.jar:/usr/lib/jvm/java-8-oracle/jre/lib/javaws.jar:/usr/lib/jvm/java-8-oracle/jre/lib/jce.jar:/usr/lib/jvm/java-8-oracle/jre/lib/jfr.jar:/usr/lib/jvm/java-8-oracle/jre/lib/jfxswt.jar:/usr/lib/jvm/java-8-oracle/jre/lib/jsse.jar:/usr/lib/jvm/java-8-oracle/jre/lib/management-agent.jar:/usr/lib/jvm/java-8-oracle/jre/lib/plugin.jar:/usr/lib/jvm/java-8-oracle/jre/lib/resources.jar:/usr/lib/jvm/java-8-oracle/jre/lib/rt.jar:/media/papus/TI31436700A/_Projects/jsweet/transpiler/target/test-classes:/media/papus/TI31436700A/_Projects/jsweet/transpiler/target/classes:/home/papus/.m2/repository/edu/princeton/cup/java-cup/10k/java-cup-10k.jar:/home/papus/.m2/repository/de/jflex/jflex/1.3.5/jflex-1.3.5.jar:/home/papus/.m2/repository/org/apache/commons/commons-lang3/3.3.2/commons-lang3-3.3.2.jar:/home/papus/.m2/repository/commons-io/commons-io/2.4/commons-io-2.4.jar:/home/papus/.m2/repository/junit/junit/4.12/junit-4.12.jar:/home/papus/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar:/home/papus/.m2/repository/log4j/log4j/1.2.17/log4j-1.2.17.jar:/home/papus/.m2/repository/com/google/code/gson/gson/2.2.4/gson-2.2.4.jar:/home/papus/.m2/repository/com/martiansoftware/jsap/2.1/jsap-2.1.jar:/home/papus/.m2/repository/ant/ant/1.6.5/ant-1.6.5.jar:/home/papus/.m2/repository/com/google/javascript/closure-compiler/v20161201/closure-compiler-v20161201.jar:/home/papus/.m2/repository/com/google/javascript/closure-compiler-externs/v20161201/closure-compiler-externs-v20161201.jar:/home/papus/.m2/repository/args4j/args4j/2.33/args4j-2.33.jar:/home/papus/.m2/repository/com/google/guava/guava/20.0/guava-20.0.jar:/home/papus/.m2/repository/com/google/protobuf/protobuf-java/3.0.2/protobuf-java-3.0.2.jar:/home/papus/.m2/repository/com/google/code/findbugs/jsr305/3.0.1/jsr305-3.0.1.jar:/home/papus/.m2/repository/com/google/jsinterop/jsinterop-annotations/1.0.0/jsinterop-annotations-1.0.0.jar:/home/papus/.m2/repository/com/sun/tools/8/tools-8.jar:/home/papus/.m2/repository/org/jsweet/jsweet-core/5-SNAPSHOT/jsweet-core-5-20170318.074022-5.jar:/home/papus/.m2/repository/org/jsweet/candies/trusted/es6-promise/0.0.0-SNAPSHOT/es6-promise-0.0.0-20161223.170926-1.jar:/home/papus/.m2/repository/org/jsweet/j4ts/0.4.0/j4ts-0.4.0.jar:/home/papus/.m2/repository/org/jsweet/candies/ext/jquery/1.10.0-SNAPSHOT/jquery-1.10.0-20170104.135047-3.jar:/home/papus/.m2/repository/org/jsweet/candies/ext/jqueryui/1.11.0-SNAPSHOT/jqueryui-1.11.0-20170104.145418-2.jar:/home/papus/.m2/repository/org/jsweet/candies/ext/backbone/1.3.0-SNAPSHOT/backbone-1.3.0-20170104.135004-4.jar:/home/papus/.m2/repository/org/jsweet/candies/ext/underscore/1.7.0-SNAPSHOT/underscore-1.7.0-20170104.145606-2.jar:/home/papus/.m2/repository/org/jsweet/candies/ext/angular/1.4.0-SNAPSHOT/angular-1.4.0-20170210.160041-4.jar:/home/papus/.m2/repository/org/jsweet/candies/ext/angular-route/1.2.0-SNAPSHOT/angular-route-1.2.0-20170103.171226-3.jar
INFO  CandyProcessor:127 - extracted candies directory: .jsweet/candies/js
INFO  StructuralTests:124 - *********************** StructuralTests.testInheritance ***********************
INFO  StructuralTests:203 - *** module kind: none ***
INFO  JSweetTranspiler:516 - [JavaScript engine] eval files: [src/test/java/source/structural/Inheritance.java]
INFO  JSweetTranspiler:329 - node version: v7.8.0
WARN: candy j4ts:0.4.0 was generated for a different version of the transpiler (current:2.0.0, candy:1.1.1)
INFO  CandyProcessor:206 - 8 candies found in classpath
INFO  CandyProcessor:154 - candies changed, processing candies: CandyStore=[(es6_promise-0.0.0-SNAPSHOT,t=1482509364000), (j4ts-0.4.0,t=1483538226000), (jquery-1.10.0-SNAPSHOT,t=1483534236000), (jqueryui-1.11.0-SNAPSHOT,t=1483538048000), (backbone-1.3.0-SNAPSHOT,t=1483534192000), (underscore-1.7.0-SNAPSHOT,t=1483538154000), (angular-1.4.0-SNAPSHOT,t=1486738832000), (angular-route-1.2.0-SNAPSHOT,t=1483459940000)]
INFO  CandyProcessor:260 - extract candy: /home/papus/.m2/repository/org/jsweet/candies/trusted/es6-promise/0.0.0-SNAPSHOT/es6-promise-0.0.0-20161223.170926-1.jar javaOutputDirectory=/media/papus/TI31436700A/_Projects/jsweet/transpiler/.jsweet/candies/src/es6-promise-0.0.0-20161223.170926-1 tsDefOutputDirectory=/media/papus/TI31436700A/_Projects/jsweet/transpiler/.jsweet/candies/typings jsOutputDir=.jsweet/candies/js/es6-promise-0.0.0-20161223.170926-1
INFO  CandyProcessor:260 - extract candy: /home/papus/.m2/repository/org/jsweet/j4ts/0.4.0/j4ts-0.4.0.jar javaOutputDirectory=/media/papus/TI31436700A/_Projects/jsweet/transpiler/.jsweet/candies/src/j4ts-0.4.0 tsDefOutputDirectory=/media/papus/TI31436700A/_Projects/jsweet/transpiler/.jsweet/candies/typings jsOutputDir=.jsweet/candies/js/j4ts-0.4.0
INFO  CandyProcessor:260 - extract candy: /home/papus/.m2/repository/org/jsweet/candies/ext/jquery/1.10.0-SNAPSHOT/jquery-1.10.0-20170104.135047-3.jar javaOutputDirectory=/media/papus/TI31436700A/_Projects/jsweet/transpiler/.jsweet/candies/src/jquery-1.10.0-20170104.135047-3 tsDefOutputDirectory=/media/papus/TI31436700A/_Projects/jsweet/transpiler/.jsweet/candies/typings jsOutputDir=.jsweet/candies/js/jquery-1.10.0-20170104.135047-3
INFO  CandyProcessor:260 - extract candy: /home/papus/.m2/repository/org/jsweet/candies/ext/jqueryui/1.11.0-SNAPSHOT/jqueryui-1.11.0-20170104.145418-2.jar javaOutputDirectory=/media/papus/TI31436700A/_Projects/jsweet/transpiler/.jsweet/candies/src/jqueryui-1.11.0-20170104.145418-2 tsDefOutputDirectory=/media/papus/TI31436700A/_Projects/jsweet/transpiler/.jsweet/candies/typings jsOutputDir=.jsweet/candies/js/jqueryui-1.11.0-20170104.145418-2
INFO  CandyProcessor:260 - extract candy: /home/papus/.m2/repository/org/jsweet/candies/ext/backbone/1.3.0-SNAPSHOT/backbone-1.3.0-20170104.135004-4.jar javaOutputDirectory=/media/papus/TI31436700A/_Projects/jsweet/transpiler/.jsweet/candies/src/backbone-1.3.0-20170104.135004-4 tsDefOutputDirectory=/media/papus/TI31436700A/_Projects/jsweet/transpiler/.jsweet/candies/typings jsOutputDir=.jsweet/candies/js/backbone-1.3.0-20170104.135004-4
INFO  CandyProcessor:260 - extract candy: /home/papus/.m2/repository/org/jsweet/candies/ext/underscore/1.7.0-SNAPSHOT/underscore-1.7.0-20170104.145606-2.jar javaOutputDirectory=/media/papus/TI31436700A/_Projects/jsweet/transpiler/.jsweet/candies/src/underscore-1.7.0-20170104.145606-2 tsDefOutputDirectory=/media/papus/TI31436700A/_Projects/jsweet/transpiler/.jsweet/candies/typings jsOutputDir=.jsweet/candies/js/underscore-1.7.0-20170104.145606-2
INFO  CandyProcessor:260 - extract candy: /home/papus/.m2/repository/org/jsweet/candies/ext/angular/1.4.0-SNAPSHOT/angular-1.4.0-20170210.160041-4.jar javaOutputDirectory=/media/papus/TI31436700A/_Projects/jsweet/transpiler/.jsweet/candies/src/angular-1.4.0-20170210.160041-4 tsDefOutputDirectory=/media/papus/TI31436700A/_Projects/jsweet/transpiler/.jsweet/candies/typings jsOutputDir=.jsweet/candies/js/angular-1.4.0-20170210.160041-4
INFO  CandyProcessor:260 - extract candy: /home/papus/.m2/repository/org/jsweet/candies/ext/angular-route/1.2.0-SNAPSHOT/angular-route-1.2.0-20170103.171226-3.jar javaOutputDirectory=/media/papus/TI31436700A/_Projects/jsweet/transpiler/.jsweet/candies/src/angular-route-1.2.0-20170103.171226-3 tsDefOutputDirectory=/media/papus/TI31436700A/_Projects/jsweet/transpiler/.jsweet/candies/typings jsOutputDir=.jsweet/candies/js/angular-route-1.2.0-20170103.171226-3
INFO  CandyProcessor:176 - found j4ts Java runtime in classpath
INFO  JSweetTranspiler:702 - parsing: RegularFileObject[src/test/java/source/structural/Inheritance.java]
INFO  JSweetTranspiler:709 - attribution phase
INFO  JSweetTranspiler:840 - scanning src/test/java/source/structural/Inheritance.java...
INFO  JSweetTranspiler:861 - output file: source/structural/Inheritance.ts
INFO  JSweetTranspiler:883 - created tempOut/StructuralTests.testInheritance/none/source/structural/Inheritance.ts
INFO  JSweetTranspiler:1238 - launching tsc...
INFO  JSweetTranspiler:1249 - source/structural/Inheritance.ts(152,27): error TS2420: Class 'AbstractIterator<T>' incorrectly implements interface 'Iterator<T>'.
ERROR: class 'AbstractIterator<T>' incorrectly implements interface 'Iterator<T>' at src/test/java/source/structural/Inheritance.java(141)
INFO  JSweetTranspiler:1249 -   Property 'forEachRemaining' is missing in type 'AbstractIterator<T>'.
INFO  JSweetTranspiler:790 - transpilation process finished in 3407 ms
java.lang.Exception: unable to evaluate: transpilation errors remain
	at org.jsweet.transpiler.JSweetTranspiler.eval(JSweetTranspiler.java:590)
	at org.jsweet.transpiler.JSweetTranspiler.eval(JSweetTranspiler.java:462)
	at org.jsweet.test.transpiler.AbstractTest.eval(AbstractTest.java:212)
	at org.jsweet.test.transpiler.AbstractTest.eval(AbstractTest.java:195)
	at org.jsweet.test.transpiler.AbstractTest.eval(AbstractTest.java:189)
	at org.jsweet.test.transpiler.AbstractTest.eval(AbstractTest.java:183)
	at org.jsweet.test.transpiler.StructuralTests.testInheritance(StructuralTests.java:149)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:51)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:237)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)

java.lang.AssertionError: exception occured while running test StructuralTests.testInheritance with module kind none

	at org.junit.Assert.fail(Assert.java:88)
	at org.jsweet.test.transpiler.AbstractTest.eval(AbstractTest.java:218)
	at org.jsweet.test.transpiler.AbstractTest.eval(AbstractTest.java:195)
	at org.jsweet.test.transpiler.AbstractTest.eval(AbstractTest.java:189)
	at org.jsweet.test.transpiler.AbstractTest.eval(AbstractTest.java:183)
	at org.jsweet.test.transpiler.StructuralTests.testInheritance(StructuralTests.java:149)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:51)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:237)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
```