### PR TITLE
Fixes two types of errors when requiring modules

### DIFF
--- a/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
@@ -491,9 +491,10 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 						if (qualified.sym != null) {
 							// regular import case (qualified.sym is a package)
 							if (context.hasAnnotationType(qualified.sym, JSweetConfig.ANNOTATION_MODULE)) {
+								String targetName = createImportAliasFromFieldAccess (qualified);
 								String actualName = context.getAnnotationValue(qualified.sym,
 										JSweetConfig.ANNOTATION_MODULE, String.class, null);
-								useModule(true, null, importDecl, qualified.name.toString(), actualName,
+								useModule(true, null, importDecl, targetName, actualName,
 										((PackageSymbol) qualified.sym));
 							}
 						} else {
@@ -506,10 +507,11 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 											if (qualified.name.equals(importedMember.getSimpleName())) {
 												if (context.hasAnnotationType(importedMember,
 														JSweetConfig.ANNOTATION_MODULE)) {
+													String targetName = createImportAliasFromSymbol (importedMember);
 													String actualName = context.getAnnotationValue(importedMember,
 															JSweetConfig.ANNOTATION_MODULE, String.class, null);
 													useModule(true, null, importDecl,
-															importedMember.getSimpleName().toString(), actualName,
+															targetName, actualName,
 															importedMember);
 													break;
 												}
@@ -746,7 +748,39 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 
 		globalModule = false;
 
+	}	
+	
+	
+	private String createImportAliasFromFieldAccess (JCFieldAccess access) {
+		String name = extractNameFromAnnotatedSymbol (access.sym);
+		if (name != null) {
+			return name;
+		} else {
+			return access.name.toString ();
+		}
 	}
+
+
+	private String createImportAliasFromSymbol (Symbol symbol) {
+		String name = extractNameFromAnnotatedSymbol (symbol);
+		if (name != null) {
+			return name;
+		} else {
+			return symbol.getSimpleName ().toString ();
+		}
+	}
+
+
+	private String extractNameFromAnnotatedSymbol (Symbol symbol) {
+		if (context.hasAnnotationType (symbol, JSweetConfig.ANNOTATION_NAME)) {
+			return context.getAnnotationValue (
+					symbol, JSweetConfig.ANNOTATION_NAME,
+					String.class, null);
+		} else {
+			return null;
+		}
+	}
+	
 
 	private void printDocComment(JCTree element, boolean indent) {
 		if (compilationUnit != null && compilationUnit.docComments != null) {

--- a/transpiler/src/main/java/org/jsweet/transpiler/extension/Java2TypeScriptAdapter.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/extension/Java2TypeScriptAdapter.java
@@ -270,7 +270,7 @@ public class Java2TypeScriptAdapter extends PrinterAdapter {
 				case "java.lang.Math":
 					return null;
 				}
-				String name = getPrinter().getRootRelativeName(fa.selected.type.tsym, context.useModules);
+				String name = getPrinter().getRootRelativeName(fa.selected.type.tsym, false);
 				String methodName = fa.name.toString();
 
 				// function is a top-level global function (no need to import)


### PR DESCRIPTION
This commit fixes the errors that come up when generating
the call to "require()" in these two situations:

  1. When importing a module that represents a namespace and contains
  a class/function with the same name that the namespace.
  Example: namespace foo and function foo.foo.
  This belongs to the issue #318.

  2. When importing a module that represents, at the same time,
  a namespace and a class/function.
  Example: namespace foo and function foo.
  This belongs to the issue #319.