### PR TITLE
Fix typescriptdef.lex charactor typo

### DIFF
--- a/candy-generator/src/main/java/org/jsweet/input/typescriptdef/parser/typescriptdef.lex
+++ b/candy-generator/src/main/java/org/jsweet/input/typescriptdef/parser/typescriptdef.lex
@@ -189,7 +189,7 @@ SpecialKeywordEnding = {WhiteSpaceChar}+ [\'\"\[A-Za-z0-9_$/]
   {LineTerminator}      { /*System.err.println("LF");*/  return symbol(sym.LF); }
   {WhiteSpaceChar}      { /* ignore */ }
   //{WhiteSpace}        { /* ignore */ }
-  [﻿] { /* ignore */ }
+  [] { /* ignore */ }
 }
 
 <STRING> {


### PR DESCRIPTION
Line 192 has a invisible charactor between [].

It is hard to see, finally I found a way, open the web editor of GitHub, it shows a red point, as below picture.
When I rewrite it to [], git tool also think it's different.

#335 

![lex](https://user-images.githubusercontent.com/4039620/29272333-21e74bdc-8132-11e7-8df9-f205980e7a0c.png)
