### PR TITLE
ProcessUtil.extraPath now works for non-windows systems.

### DIFF
--- a/transpiler/pom.xml
+++ b/transpiler/pom.xml
@@ -154,7 +154,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.3.2</version>
+			<version>3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>

--- a/transpiler/src/main/java/org/jsweet/transpiler/util/ProcessUtil.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/util/ProcessUtil.java
@@ -180,15 +180,16 @@ public class ProcessUtil {
 			} else {
 				cmd = new String[] { "cmd", "/c", command };
 			}
+			cmd = ArrayUtils.addAll(cmd, args);
 		} else {
 			if (nodeCommands.contains(command)) {
 				cmd = new String[] { getNpmPath(command) };
+				cmd = ArrayUtils.addAll(cmd, args);
 			} else {
-				cmd = new String[] { command };
+				String cmdAndArgs = StringUtils.join(ArrayUtils.insert(0, args, command), " ");
+				cmd = new String[] { "/bin/sh", "-c", cmdAndArgs };
 			}
 		}
-		cmd = ArrayUtils.addAll(cmd, args);
-
 		logger.debug("run command: " + StringUtils.join(cmd, " "));
 		Process[] process = { null };
 		try {


### PR DESCRIPTION
`new ProcessBuilder("node", "--version")` doesn't work, it has to be `new ProcessBuilder("/bin/sh", "-c", "node --version")`.