### PR TITLE
Issue 427 Parameter Destructuring

### DIFF
--- a/core-lib/es6/src/main/java/jsweet/lang/Wrapped.java
+++ b/core-lib/es6/src/main/java/jsweet/lang/Wrapped.java
@@ -1,0 +1,39 @@
+/* 
+ * JSweet - http://www.jsweet.org
+ * Copyright (C) 2015 CINCHEO SAS <renaud.pawlak@cincheo.fr>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jsweet.lang;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Use this annotation to indicate a method that should have it's parameters wrapped in a parameter object.
+ * 
+ * 
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.CONSTRUCTOR })
+@Documented
+public @interface Wrapped
+{
+	/**
+	 * The interface that defines the wrapper class to use
+	 */
+	Class<?> target();
+}

--- a/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
@@ -2207,35 +2207,7 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 			inTypeParameters = false;
 		}
 		print("(");
-		if (inCoreWrongOverload) {
-			getScope().eraseVariableTypes = true;
-		}
-		boolean paramPrinted = false;
-		if (getScope().innerClassNotStatic && methodDecl.sym.isConstructor() && !getScope().enumWrapperClassScope) {
-			print(PARENT_CLASS_FIELD_NAME + ": any, ");
-			paramPrinted = true;
-		}
-		if (getScope().constructor && getScope().enumWrapperClassScope) {
-			print((isAnonymousClass() ? "" : "protected ") + ENUM_WRAPPER_CLASS_ORDINAL + " : number, ");
-			print((isAnonymousClass() ? "" : "protected ") + ENUM_WRAPPER_CLASS_NAME + " : string, ");
-			paramPrinted = true;
-		}
-		int i = 0;
-		for (JCVariableDecl param : methodDecl.getParameters()) {
-			print(param);
-			if (inOverload && overload.isValid && overload.defaultValues.get(i) != null) {
-				print(" = ").print(overload.defaultValues.get(i));
-			}
-			print(", ");
-			i++;
-			paramPrinted = true;
-		}
-		if (inCoreWrongOverload) {
-			getScope().eraseVariableTypes = false;
-		}
-		if (paramPrinted) {
-			removeLastChars(2);
-		}
+		printConstructorArgs(methodDecl, overload, inOverload, inCoreWrongOverload);
 		print(")");
 		if (inCoreWrongOverload && !methodDecl.sym.isConstructor()) {
 			print(" : any");
@@ -2279,7 +2251,7 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 					print(" {").println().startIndent().printIndent();
 
 					boolean wasPrinted = false;
-					for (i = 0; i < overload.methods.size(); i++) {
+					for (int i = 0; i < overload.methods.size(); i++) {
 						JCMethodDecl method = overload.methods.get(i);
 						if (context.isInterface((ClassSymbol) method.sym.getEnclosingElement())
 								&& !method.getModifiers().getFlags().contains(Modifier.DEFAULT)
@@ -2388,6 +2360,47 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 					endIndent().printIndent().print("}");
 				}
 			}
+		}
+	}
+	
+	protected void printConstructorArgs(JCMethodDecl methodDecl, Overload overload, boolean inOverload,
+			boolean inCoreWrongOverload)
+	{
+		if (inCoreWrongOverload)
+		{
+			getScope().eraseVariableTypes = true;
+		}
+		boolean paramPrinted = false;
+		if (getScope().innerClassNotStatic && methodDecl.sym.isConstructor() && !getScope().enumWrapperClassScope)
+		{
+			print(PARENT_CLASS_FIELD_NAME + ": any, ");
+			paramPrinted = true;
+		}
+		if (getScope().constructor && getScope().enumWrapperClassScope)
+		{
+			print((isAnonymousClass() ? "" : "protected ") + ENUM_WRAPPER_CLASS_ORDINAL + " : number, ");
+			print((isAnonymousClass() ? "" : "protected ") + ENUM_WRAPPER_CLASS_NAME + " : string, ");
+			paramPrinted = true;
+		}
+		int i = 0;
+		for (JCVariableDecl param : methodDecl.getParameters())
+		{
+			print(param);
+			if (inOverload && overload.isValid && overload.defaultValues.get(i) != null)
+			{
+				print(" = ").print(overload.defaultValues.get(i));
+			}
+			print(", ");
+			i++;
+			paramPrinted = true;
+		}
+		if (inCoreWrongOverload)
+		{
+			getScope().eraseVariableTypes = false;
+		}
+		if (paramPrinted)
+		{
+			removeLastChars(2);
 		}
 	}
 

--- a/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
@@ -348,7 +348,7 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 
 		private boolean decoratorScope = false;
 
-		protected String getName()
+		public String getName()
 		{
 			return name;
 		}
@@ -401,6 +401,11 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 		protected boolean isEraseVariableTypes()
 		{
 			return eraseVariableTypes;
+		}
+
+		public void setEraseVariableTypes(boolean eraseVariableTypes)
+		{
+			this.eraseVariableTypes = eraseVariableTypes;
 		}
 
 		protected boolean isHasDeclaredConstructor()
@@ -1112,13 +1117,6 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 	 * A flags that indicates that this adapter is not substituting types.
 	 */
 	private boolean disableTypeSubstitution = false;
-	
-	private String argumentInterfaceName = null;
-	
-	public String getArgumentInterfaceName()
-	{
-		return argumentInterfaceName;
-	}
 
 	public final AbstractTreePrinter substituteAndPrintType(JCTree typeTree) {
 		return substituteAndPrintType(typeTree, false, inTypeParameters, true, disableTypeSubstitution);
@@ -1392,12 +1390,6 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 		}
 		return name;
 	}
-	
-	protected String printArgumentInterfaces(String name)
-	{
-		//override this method to add interfaces for method argument lists
-		return null;
-	}
 
 	@Override
 	public void visitClassDef(JCClassDecl classdecl) {
@@ -1489,7 +1481,7 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 				print("/** @ignore */").println().printIndent();
 			}
 			print(classdecl.mods);
-			argumentInterfaceName = printArgumentInterfaces(name);
+
 			if (!isTopLevelScope() || context.useModules || isAnonymousClass() || isInnerClass() || isLocalClass()) {
 				print("export ");
 			}
@@ -2522,7 +2514,7 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 	{
 		if (inCoreWrongOverload)
 		{
-			scope.eraseVariableTypes = true;
+			scope.setEraseVariableTypes(true);
 		}
 		boolean paramPrinted = false;
 		if (scope.innerClassNotStatic && methodDecl.sym.isConstructor() && !scope.enumWrapperClassScope)
@@ -2550,7 +2542,7 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 		}
 		if (inCoreWrongOverload)
 		{
-			scope.eraseVariableTypes = false;
+			scope.setEraseVariableTypes(false);
 		}
 		if (paramPrinted)
 		{
@@ -3145,7 +3137,7 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 				print(name);
 			}
 
-			if (!Util.isVarargs(varDecl) && (getScope().eraseVariableTypes || (getScope().interfaceScope
+			if (!Util.isVarargs(varDecl) && (getScope().isEraseVariableTypes() || (getScope().interfaceScope
 					&& context.hasAnnotationType(varDecl.sym, JSweetConfig.ANNOTATION_OPTIONAL)))) {
 				print("?");
 			}
@@ -3155,7 +3147,7 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 					if (confictInDefinitionScope) {
 						print("any");
 					} else {
-						if (getScope().eraseVariableTypes) {
+						if (getScope().isEraseVariableTypes()) {
 							print("any");
 							if (Util.isVarargs(varDecl)) {
 								print("[]");

--- a/transpiler/src/test/java/org/jsweet/test/transpiler/ExtensionTests.java
+++ b/transpiler/src/test/java/org/jsweet/test/transpiler/ExtensionTests.java
@@ -109,22 +109,7 @@ class TestConstructorAdapter extends Java2TypeScriptAdapter
 	{
 		super(context);
 
-	}
-	
-//	@Override
-//	public void afterType(TypeElement type)
-//	{
-//		
-//		String name = type.getSimpleName().toString();
-//		String iName = null;
-//		if(name != null)
-//		{
-//			iName = "I" + name;
-//			print("interface " + iName + "{");
-//			print("}").println();
-//		}
-//		
-//	}
+	}	
 	
 }
 

--- a/transpiler/src/test/java/org/jsweet/test/transpiler/ExtensionTests.java
+++ b/transpiler/src/test/java/org/jsweet/test/transpiler/ExtensionTests.java
@@ -145,16 +145,15 @@ class TestConstructorTranslator extends Java2TypeScriptTranslator {
 	{
 		Type parameterClass = null;
 		boolean isWrapped = false;
-		if(this.context.hasAnnotationType(methodDecl.sym, JSweetConfig.LANG_PACKAGE + ".Wrapped"))
+		if(this.context.hasAnnotationType(methodDecl.sym, "source.extension.Wrapped"))
 		{
-			parameterClass = this.context.getAnnotationValue(methodDecl.sym, JSweetConfig.LANG_PACKAGE + ".Wrapped", "target", Type.class, null);
+			parameterClass = this.context.getAnnotationValue(methodDecl.sym, "source.extension.Wrapped", "target", Type.class, null);
 			isWrapped = true;
 		}
 		if(isWrapped)
 		{
 		print("{");
 		}
-//		super.printConstructorArgs(methodDecl, overload, inOverload, true, scope);
 
 		if (inCoreWrongOverload)
 		{
@@ -201,18 +200,7 @@ class TestConstructorTranslator extends Java2TypeScriptTranslator {
 		}
 		
 		if(isWrapped)
-		{
-			
-			String iName = scope.getName() != null ? scope.getName() + "." + parameterClass.getClass() : null;
-//			if(iName != null)
-//			{
-//				iName = ":" + iName;
-//			}
-//			else
-//			{
-//				iName = "";
-//			}			
-		
+		{					
 			print("} ");
 			if(parameterClass != null)
 			{

--- a/transpiler/src/test/java/source/extension/FooArgsDto.java
+++ b/transpiler/src/test/java/source/extension/FooArgsDto.java
@@ -1,0 +1,57 @@
+package source.extension;
+
+import java.util.Date;
+
+import jsweet.lang.Interface;
+import jsweet.lang.Wrapped;
+
+public class FooArgsDto {
+
+	@Interface
+	public class FooArgsDtoParameter
+	{
+		public String msg;
+		public Date date;
+		public Integer quantity;
+		public String[] items;
+
+	}
+	
+	public String msg;
+	private Date date;
+	protected Integer quantity;
+	public String[] items;
+
+	@Wrapped(target=FooArgsDtoParameter.class)
+	public FooArgsDto(String msg, Date date, Integer quantity, String[] items)
+	{
+		super();
+		this.msg = msg;
+		this.date = date;
+		this.quantity = quantity;
+		this.items = items;
+	}
+
+	public String getMsg() {
+		return msg;
+	}
+
+	public void setMsg(String msg) {
+		this.msg = msg;
+	}
+
+	/**
+	 * Gets the date.
+	 */
+	public Date getDate() {
+		return date;
+	}
+
+	/**
+	 * Sets the date.
+	 */
+	public void setDate(Date date) {
+		this.date = date;
+	}
+
+}

--- a/transpiler/src/test/java/source/extension/FooArgsDto.java
+++ b/transpiler/src/test/java/source/extension/FooArgsDto.java
@@ -3,7 +3,6 @@ package source.extension;
 import java.util.Date;
 
 import jsweet.lang.Interface;
-import jsweet.lang.Wrapped;
 
 public class FooArgsDto {
 

--- a/transpiler/src/test/java/source/extension/Wrapped.java
+++ b/transpiler/src/test/java/source/extension/Wrapped.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package jsweet.lang;
+package source.extension;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;


### PR DESCRIPTION
A proof of concept for allowing Java methods to generate TypeScript methods with parameters wrapped inside an object. The only modifications to jsweet itself are the changes to the visitMethodDef() method of Java2TypeScriptTranslator to facilitate extension. The actual conversion process is demonstrated in the ExtensionTests.

The actual work of modifying the TypeScript methods is done using a custom translator and a @Wrapped annotation. By using an annotation, the Java source classes control which methods, if any, have destructuring applied. The annotation also determines the interface that the parameter object will conform to. 