### PR TITLE
Fix NPE for HashMap subclass with static methods

### DIFF
--- a/transpiler/src/main/java/org/jsweet/transpiler/model/support/MethodInvocationElementSupport.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/model/support/MethodInvocationElementSupport.java
@@ -90,6 +90,9 @@ public class MethodInvocationElementSupport extends ExtendedElementSupport<JCMet
 	@Override
 	public ExtendedElement getTargetExpression() {
 		JCTree methTree = tree.meth;
+		if (methTree instanceof JCIdent) {
+			return ExtendedElementFactory.INSTANCE.create(((JCIdent) methTree));
+		}
 		if (methTree instanceof JCFieldAccess) {
 			return ExtendedElementFactory.INSTANCE.create(((JCFieldAccess) methTree).selected);
 		} else {


### PR DESCRIPTION
A NullPointer is thrown when a subclass of a Map implementation has a static method that calls another static method without referencing its own class name (so, below, `DummyClass.firstMethod()` works). Other changes, like type parameters, access modifiers, return types, method parameters, etc, are irrelevant.

This is the smallest example I could create:

```
package somethingsomething;
public class DummyClass extends java.util.HashMap {
    private static void firstMethod() {}
    public static void secondMethod() {
        firstMethod();
    }
}
```

The relevant part of the stack trace:

```
java.lang.NullPointerException
	at org.jsweet.transpiler.extension.RemoveJavaDependenciesAdapter.substituteMethodInvocationOnMap(RemoveJavaDependenciesAdapter.java:921)
	at org.jsweet.transpiler.extension.RemoveJavaDependenciesAdapter.substituteMethodInvocation(RemoveJavaDependenciesAdapter.java:262)
	at org.jsweet.transpiler.Java2TypeScriptTranslator.visitApply(Java2TypeScriptTranslator.java:3467)
	at com.sun.tools.javac.tree.JCTree$JCMethodInvocation.accept(JCTree.java:1465)
	at org.jsweet.transpiler.util.AbstractTreeScanner.scan(AbstractTreeScanner.java:238)
	at com.sun.tools.javac.tree.TreeScanner.visitExec(TreeScanner.java:175)
	at com.sun.tools.javac.tree.JCTree$JCExpressionStatement.accept(JCTree.java:1296)
	at org.jsweet.transpiler.util.AbstractTreeScanner.scan(AbstractTreeScanner.java:238)
```

The cause of this is that `MethodInvocationElementSupport.getTargetExpression` returns `null`, because it lacks the condition `if (methTree instanceof JCIdent)` like in the other overridden methods.