### PR TITLE
Support try-with-resources (by closing in finally)

### DIFF
--- a/transpiler/src/main/java/org/jsweet/transpiler/JSweetProblem.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/JSweetProblem.java
@@ -418,8 +418,6 @@ public enum JSweetProblem {
 			return String.format("method '%s' cannot be native", params);
 		case TRY_WITHOUT_CATCH_OR_FINALLY:
 			return String.format("try statement must define at least a catch or a finally clause", params);
-		case UNSUPPORTED_TRY_WITH_RESOURCE:
-			return String.format("try-with-resource statement is not supported", params);
 		case TRY_WITH_MULTIPLE_CATCHES:
 			return String.format("try statement cannot define more than one catch clause", params);
 		case GLOBAL_INDEXER_GET:

--- a/transpiler/src/test/java/org/jsweet/test/transpiler/ThrowableTests.java
+++ b/transpiler/src/test/java/org/jsweet/test/transpiler/ThrowableTests.java
@@ -54,7 +54,7 @@ public class ThrowableTests extends AbstractTest {
 	@Test
 	public void testInvalidTryCatch() {
 		transpile(ModuleKind.none, logHandler -> {
-			logHandler.assertReportedProblems(JSweetProblem.UNSUPPORTED_TRY_WITH_RESOURCE, JSweetProblem.TRY_WITHOUT_CATCH_OR_FINALLY);
+			logHandler.assertReportedProblems(JSweetProblem.TRY_WITHOUT_CATCH_OR_FINALLY);
 		}, getSourceFile(InvalidTryCatchTest.class));
 	}
 

--- a/transpiler/src/test/java/org/jsweet/test/transpiler/ThrowableTests.java
+++ b/transpiler/src/test/java/org/jsweet/test/transpiler/ThrowableTests.java
@@ -26,6 +26,7 @@ import source.throwable.InvalidTryCatchTest;
 import source.throwable.MultipleTryCatchTest;
 import source.throwable.Throwables;
 import source.throwable.TryCatchFinallyTest;
+import source.throwable.TryWithResourcesTest;
 
 public class ThrowableTests extends AbstractTest {
 
@@ -54,8 +55,15 @@ public class ThrowableTests extends AbstractTest {
 	@Test
 	public void testInvalidTryCatch() {
 		transpile(ModuleKind.none, logHandler -> {
-			logHandler.assertReportedProblems(JSweetProblem.TRY_WITHOUT_CATCH_OR_FINALLY);
+			logHandler.assertReportedProblems(JSweetProblem.MAPPED_TSC_ERROR, JSweetProblem.MAPPED_TSC_ERROR, JSweetProblem.MAPPED_TSC_ERROR);
 		}, getSourceFile(InvalidTryCatchTest.class));
+	}
+
+	@Test
+	public void testTryWithResources() {
+		eval(ModuleKind.none, (logHandler, result) -> {
+			Assert.assertEquals("There should be no errors", 0, logHandler.reportedProblems.size());
+		}, getSourceFile(TryWithResourcesTest.class));
 	}
 
 	@Test

--- a/transpiler/src/test/java/source/throwable/TryWithResourcesTest.java
+++ b/transpiler/src/test/java/source/throwable/TryWithResourcesTest.java
@@ -12,8 +12,31 @@ public class TryWithResourcesTest {
         }
     }
 
+    void singleResourceWithCatchMethod() throws Exception {
+        try (CloseClass one = new CloseClass()) {
+        }
+        catch (Exception e) {
+        }
+    }
+
+    void singleResourceWithFinallyMethod() throws Exception {
+        try (CloseClass one = new CloseClass()) {
+        }
+        finally {
+        }
+    }
+
+    void singleResourceWithCatchAndFinallyMethod() throws Exception {
+        try (CloseClass one = new CloseClass()) {
+        }
+        catch (Exception e) {
+        }
+        finally {
+        }
+    }
+    
     /* output of this test should be equal to #multipleResourcesMethod */
-    public void tryFinallyMethod() throws Exception {
+    public void regularTryFinallyMethod() throws Exception {
         CloseClass one = new CloseClass();
         CloseClass two = new CloseClass();
         try {

--- a/transpiler/src/test/java/source/throwable/TryWithResourcesTest.java
+++ b/transpiler/src/test/java/source/throwable/TryWithResourcesTest.java
@@ -1,0 +1,51 @@
+package source.throwable;
+
+public class TryWithResourcesTest {
+
+    void singleResourceMethod() throws Exception {
+        try (CloseClass one = new CloseClass()) {
+        }
+    }
+
+    void multipleResourcesMethod() throws Exception {
+        try (CloseClass one = new CloseClass(); CloseClass two = new CloseClass()) {
+        }
+    }
+
+    /* output of this test should be equal to #multipleResourcesMethod */
+    public void tryFinallyMethod() throws Exception {
+        CloseClass one = new CloseClass();
+        CloseClass two = new CloseClass();
+        try {
+        } finally {
+            two.close();
+            one.close();
+        }
+    }
+
+    void resourcesAndTryFinallyMethod() throws Exception {
+        CloseClass one = new CloseClass();
+        try (CloseClass two = new CloseClass(); CloseClass three = new CloseClass()) {
+        } finally {
+            one.close();
+        }
+    }
+
+    void nestedResourceMethod() throws Exception {
+        try (CloseClass one = new CloseClass()) {
+            try (CloseClass two = new CloseClass()) {
+            }
+        }
+    }
+}
+
+/**
+ * Dummy class that fulfills the minimum requirement to act as a resource for a
+ * try-with-resources clause.
+ */
+class CloseClass implements AutoCloseable {
+
+    @Override
+    public void close() throws Exception {
+    }
+}


### PR DESCRIPTION
Fixes #437 , but tests are unlikely to run correctly. My test file is this:

input:

```java
public class ResourceTest {

    void test1() throws Exception {
        try (CloseClass one = new CloseClass(); CloseClass two = new CloseClass()) {
        }
    }

    void test2() throws Exception {
        CloseClass one = new CloseClass();
        CloseClass two = new CloseClass();
        try {
        } finally {
            two.close();
            one.close();
        }
    }

    void test3() throws Exception {
        CloseClass one = new CloseClass();
        try (CloseClass two = new CloseClass(); CloseClass three = new CloseClass()) {
        } finally {
            one.close();
        }
    }

    void test4() throws Exception {
        try (CloseClass one = new CloseClass()) {
            try (CloseClass two = new CloseClass()) {
            }
        }
    }
}

class CloseClass implements AutoCloseable {

    @Override
    public void close() throws Exception {
    }
}
```

output:

```typescript
/* Generated from Java with JSweet 2.2.0-SNAPSHOT - http://www.jsweet.org */
namespace quickstart {
    export class ResourceTest {
        test1() {
            let one : quickstart.CloseClass = new quickstart.CloseClass();
            let two : quickstart.CloseClass = new quickstart.CloseClass();
            try {
            } finally {
                two.close();
                one.close();
            };
        }

        test2() {
            let one : quickstart.CloseClass = new quickstart.CloseClass();
            let two : quickstart.CloseClass = new quickstart.CloseClass();
            try {
            } finally {
                two.close();
                one.close();
            };
        }

        test3() {
            let one : quickstart.CloseClass = new quickstart.CloseClass();
            let two : quickstart.CloseClass = new quickstart.CloseClass();
            let three : quickstart.CloseClass = new quickstart.CloseClass();
            try {
            } finally {
                three.close();
                two.close();
                one.close();
            };
        }

        test4() {
            let one : quickstart.CloseClass = new quickstart.CloseClass();
            try {
                let two : quickstart.CloseClass = new quickstart.CloseClass();
                try {
                } finally {
                    two.close();
                };
            } finally {
                one.close();
            };
        }
    }
    ResourceTest["__class"] = "quickstart.ResourceTest";


    export class CloseClass {
        /**
         * 
         */
        public close() {
        }

        constructor() {
        }
    }
    CloseClass["__class"] = "quickstart.CloseClass";
    CloseClass["__interfaces"] = ["java.lang.AutoCloseable"];


}

```