### PR TITLE
if hashCode has argument, then print original

### DIFF
--- a/transpiler/src/main/java/org/jsweet/transpiler/extension/Java2TypeScriptAdapter.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/extension/Java2TypeScriptAdapter.java
@@ -1202,10 +1202,16 @@ public class Java2TypeScriptAdapter extends PrinterAdapter {
 			print(".constructor)");
 			return true;
 		case "hashCode":
-			printMacroName(targetMethodName);
-			print("(<any>((o: any) => { if(o.hashCode) { return o.hashCode(); } else { return o.toString(); } })(");
-			printTarget(invocationElement.getTargetExpression());
-			print("))");
+			if (invocationElement.getArgumentCount() > 0) {
+				printTarget(invocationElement.getTargetExpression()).print(".hashCode(");
+				printArgList(invocationElement.getArguments());
+				print(")");
+			} else {
+				printMacroName(targetMethodName);
+				print("(<any>((o: any) => { if(o.hashCode) { return o.hashCode(); } else { return o.toString(); } })(");
+				printTarget(invocationElement.getTargetExpression());
+				print("))");
+			}
 			return true;
 		case "equals":
 			if (invocationElement.getTargetExpression() != null) {


### PR DESCRIPTION
There is an issue with hashCode, if some class has static hashCode function, the transpiler drops these arguments
https://github.com/cincheo/jsweet/issues/447

I think it need to be separated handling this from the Object.hashCode function.
