### PR TITLE
HELP - java.util.concurrent.Future.get() handling as await

### DIFF
--- a/transpiler/src/main/java/org/jsweet/transpiler/extension/Java2TypeScriptAdapter.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/extension/Java2TypeScriptAdapter.java
@@ -73,7 +73,6 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 
-import com.sun.tools.javac.code.Type;
 import org.apache.commons.lang3.StringUtils;
 import org.jsweet.JSweetConfig;
 import org.jsweet.transpiler.JSweetContext;
@@ -104,6 +103,8 @@ import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.TypeSymbol;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.Type.ClassType;
 import com.sun.tools.javac.code.Type.MethodType;
 import com.sun.tools.javac.tree.JCTree.JCClassDecl;
 import com.sun.tools.javac.tree.JCTree.JCEnhancedForLoop;
@@ -363,11 +364,11 @@ public class Java2TypeScriptAdapter extends PrinterAdapter {
 		// least do it conditionally).
 		if (hasAnnotationType(invocationElement.getMethod(), ANNOTATION_ERASED)
 				&& !isAmbientDeclaration(invocationElement.getMethod())) {
-			// there is the hacked functions:
+			// there is the hacked Future.get() functions:
 			if (targetMethodName.equals("get") &&
 					!invocationElement.getMethod().getModifiers().contains(Modifier.STATIC) &&
-					targetType.asType() instanceof Type.ClassType) {
-				for (Type type : ((Type.ClassType) targetType.asType()).all_interfaces_field) {
+					targetType.asType() instanceof ClassType) {
+				for (Type type : ((ClassType) targetType.asType()).all_interfaces_field) {
 					if (type.tsym.toString().equals(Future.class.getName())) {
 						if (invocationElement.getArgumentCount() == 0) {
 							print("(await ").print(invocationElement.getTargetExpression()).print(".getPromise())");

--- a/transpiler/src/main/java/org/jsweet/transpiler/extension/Java2TypeScriptAdapter.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/extension/Java2TypeScriptAdapter.java
@@ -378,8 +378,8 @@ public class Java2TypeScriptAdapter extends PrinterAdapter {
 									.printArgList(invocationElement.getArguments()).print(")]" +
 									"))");
 						}
+						return true;
 					}
-					return true;
 				}
 			}
 


### PR DESCRIPTION
Hi, I want to implement java.util.concurrent.* package classes with helps of [es6_promise.Promise](https://github.com/jsweet-candies/candy-es6-promise) and javascript async/await (#138)

I came up with the idea of the following:
This is the [Future](https://docs.oracle.com/javase/8/docs/api/?java/util/concurrent/Future.html) 'like' interface, which "get" function works as an await function.
```
package java.util.concurrent;

import def.es6_promise.Promise;
import java.util.function.Consumer;
import jsweet.lang.Erased;

import static def.dom.Globals.setTimeout;

public interface Future<V> {
    @Erased
    default V get() {
        // this method calls compiles to "await this.getPromise()"
        return null;
    }
    
    @Erased
    default V get(long timeout, /* TimeUnit */ int timeunit) {
        // this method calls compiles to 
        // "await Promise.race([this.getPromise(), java.util.concurrent.Future.delay(timeout, timeunit)])"
        return null;
    }
    
    Promise<V> getPromise();
    
    static <T> Promise<T> delay(long timeout, /* TimeUnit */ int timeunit) {
        return new Promise<T>((Promise.CallbackBiConsumer<Consumer<T>, Consumer<Object>>)(result, error) -> {
            setTimeout(((Runnable)() -> result.accept(null)), timeout /* with TimeUnit ... */ );
        });
    }
}
```

There are many decisions behind this implementation, this is what is working currently for me.

I annotated the get() methods with @ Erased, because I dont want to generate this method at class implementations, because it is not gonna run (only the await command). Probably if we want to handle separatly @ Erased and "@ Unused" functions, we need implement that.

------------

So this pull request is about the above described language functionality supplement.
I do not know the followings:
- how to get fairly the information of that targetType is an implementation of Future interface (with any layer between them). I hacked a solution for that. This is acceptable?
- without the type mapping of Promise it is not worked, because the compiler wrote a dot before "Promise" at Future.delay return type [here](https://github.com/cincheo/jsweet/blob/master/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java#L3978). Possible a bug? Do I need to change anything in here?
- is it OK if I used @ Erased annotation for that?

Thanks,
Béla


