### PR TITLE
async modifier need to go closer to "function"

### DIFF
--- a/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
@@ -2224,11 +2224,11 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 			printDocComment(methodDecl);
 		}
 
-		if (context.hasAnnotationType(methodDecl.sym, JSweetConfig.ANNOTATION_ASYNC)) {
-			print(" async ");
-		}
-
 		if (parent == null) {
+			if (context.hasAnnotationType(methodDecl.sym, JSweetConfig.ANNOTATION_ASYNC)) {
+				print(" async ");
+			}
+
 			print("function ");
 		} else if (globals) {
 			if (getScope().constructor && methodDecl.sym.isPrivate() && methodDecl.getParameters().isEmpty()) {
@@ -2268,9 +2268,19 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 			if (ambient || (getIndent() == 0 && isDefinitionScope)) {
 				print("declare ");
 			}
+
+			if (context.hasAnnotationType(methodDecl.sym, JSweetConfig.ANNOTATION_ASYNC)) {
+				print(" async ");
+			}
+
 			print("function ");
 		} else {
 			printMethodModifiers(methodDecl, parent, getScope().constructor, inOverload, overload);
+
+			if (context.hasAnnotationType(methodDecl.sym, JSweetConfig.ANNOTATION_ASYNC)) {
+				print(" async ");
+			}
+
 			if (ambient) {
 				report(methodDecl, methodDecl.name, JSweetProblem.WRONG_USE_OF_AMBIENT, methodDecl.name);
 			}


### PR DESCRIPTION
currently if I wrote in some interface:
```
    @Async
    static <T> Promise<T> delay(long timeout, TimeUnit timeunit) {
```
```
2018-07-09 05:36:30.030 INFO  TypeScript2JavaScriptWithTscTranspiler:90 - bundle.ts(369,16): error TS1029: 'export' modifier must precede 'async' modifier.
2018-07-09 05:36:30.030 ERROR output:55 - 'export' modifier must precede 'async' modifier at /media/qqcs/Programs/git/j4ts-concurrent/src/main/java/java/util/concurrent/Future.java(28)
```

or public function
```
    @Async
    public Promise<Void> asd() {
```
```
2018-07-09 05:38:37.037 INFO  TypeScript2JavaScriptWithTscTranspiler:90 - bundle.ts(948,16): error TS1029: 'public' modifier must precede 'async' modifier.
2018-07-09 05:38:37.037 ERROR output:55 - 'public' modifier must precede 'async' modifier at /media/qqcs/Programs/git/j4ts-concurrent/src/main/java/java/lang/Thread.java(310)
```
I got an error