### PR TITLE
@Inline

### DIFF
--- a/core-lib/es6/src/main/java/jsweet/lang/Inline.java
+++ b/core-lib/es6/src/main/java/jsweet/lang/Inline.java
@@ -5,6 +5,7 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })
 @Documented
-public @interface Inlined {
+public @interface Inline {
+
 }
 

--- a/core-lib/es6/src/main/java/jsweet/lang/Inlined.java
+++ b/core-lib/es6/src/main/java/jsweet/lang/Inlined.java
@@ -1,0 +1,10 @@
+package jsweet.lang;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD })
+@Documented
+public @interface Inlined {
+}
+

--- a/transpiler/src/main/java/org/jsweet/JSweetConfig.java
+++ b/transpiler/src/main/java/org/jsweet/JSweetConfig.java
@@ -254,9 +254,9 @@ public abstract class JSweetConfig {
 	 */
 	public static final String ANNOTATION_ERASED = JSweetConfig.LANG_PACKAGE + ".Erased";
 	/**
-	 * Fully-qualified name for the JSweet <code>@Inlined</code> annotation (see JSweet core API).
+	 * Fully-qualified name for the JSweet <code>@Inline</code> annotation (see JSweet core API).
 	 */
-	public static final String ANNOTATION_INLINED = JSweetConfig.LANG_PACKAGE + ".Inlined";
+	public static final String ANNOTATION_INLINE = JSweetConfig.LANG_PACKAGE + ".Inline";
 	/**
 	 * Fully-qualified name for the JSweet <code>@Async</code> annotation (see JSweet core API).
 	 */

--- a/transpiler/src/main/java/org/jsweet/JSweetConfig.java
+++ b/transpiler/src/main/java/org/jsweet/JSweetConfig.java
@@ -254,6 +254,10 @@ public abstract class JSweetConfig {
 	 */
 	public static final String ANNOTATION_ERASED = JSweetConfig.LANG_PACKAGE + ".Erased";
 	/**
+	 * Fully-qualified name for the JSweet <code>@Inlined</code> annotation (see JSweet core API).
+	 */
+	public static final String ANNOTATION_INLINED = JSweetConfig.LANG_PACKAGE + ".Inlined";
+	/**
 	 * Fully-qualified name for the JSweet <code>@Async</code> annotation (see JSweet core API).
 	 */
 	public static final String ANNOTATION_ASYNC = JSweetConfig.LANG_PACKAGE + ".Async";

--- a/transpiler/src/main/java/org/jsweet/transpiler/GlobalBeforeTranslationScanner.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/GlobalBeforeTranslationScanner.java
@@ -163,6 +163,12 @@ public class GlobalBeforeTranslationScanner extends AbstractTreeScanner {
 		if (methodDecl.mods.getFlags().contains(Modifier.DEFAULT)) {
 			getContext().addDefaultMethod(compilationUnit, getParent(JCClassDecl.class), methodDecl);
 		}
+
+		if (getContext().hasAnnotationType(methodDecl.sym, JSweetConfig.ANNOTATION_INLINED) &&
+				methodDecl.params.size() == 0) {
+			getContext().addInlinedMethod(methodDecl);
+		}
+
 		if (!getContext().ignoreWildcardBounds) {
 			scan(methodDecl.params);
 		}

--- a/transpiler/src/main/java/org/jsweet/transpiler/GlobalBeforeTranslationScanner.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/GlobalBeforeTranslationScanner.java
@@ -164,8 +164,7 @@ public class GlobalBeforeTranslationScanner extends AbstractTreeScanner {
 			getContext().addDefaultMethod(compilationUnit, getParent(JCClassDecl.class), methodDecl);
 		}
 
-		if (getContext().hasAnnotationType(methodDecl.sym, JSweetConfig.ANNOTATION_INLINED) &&
-				methodDecl.params.size() == 0) {
+		if (getContext().hasAnnotationType(methodDecl.sym, JSweetConfig.ANNOTATION_INLINE)) {
 			getContext().addInlinedMethod(methodDecl);
 		}
 

--- a/transpiler/src/main/java/org/jsweet/transpiler/JSweetContext.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/JSweetContext.java
@@ -1014,8 +1014,8 @@ public class JSweetContext extends Context {
 	/**
 	 * Stores an inlined method with the symbol.
 	 */
-	public void addInlinedMethod(JCMethodDecl defaultMethod) {
-		inlinedMethod.put(defaultMethod.sym, defaultMethod);
+	public void addInlinedMethod(JCMethodDecl inlineMethod) {
+		inlinedMethod.put(inlineMethod.sym, inlineMethod);
 	}
 
 	/**

--- a/transpiler/src/main/java/org/jsweet/transpiler/JSweetContext.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/JSweetContext.java
@@ -1000,8 +1000,23 @@ public class JSweetContext extends Context {
 		return b.toString();
 	}
 
+	private Map<ExecutableElement, JCMethodDecl> inlinedMethod = new HashMap<>();
 	private Map<TypeSymbol, Set<Entry<JCClassDecl, JCMethodDecl>>> defaultMethods = new HashMap<>();
 	private Map<JCMethodDecl, JCCompilationUnit> defaultMethodsCompilationUnits = new HashMap<>();
+
+	/**
+	 * Gets the inlined methods declared in the given type.
+	 */
+	public JCMethodDecl getInlinedMethod(ExecutableElement type) {
+		return inlinedMethod.get(type);
+	}
+
+	/**
+	 * Stores an inlined method with the symbol.
+	 */
+	public void addInlinedMethod(JCMethodDecl defaultMethod) {
+		inlinedMethod.put(defaultMethod.sym, defaultMethod);
+	}
 
 	/**
 	 * Gets the default methods declared in the given type.
@@ -1014,11 +1029,7 @@ public class JSweetContext extends Context {
 	 * Stores a default method AST for the given type.
 	 */
 	public void addDefaultMethod(JCCompilationUnit compilationUnit, JCClassDecl type, JCMethodDecl defaultMethod) {
-		Set<Entry<JCClassDecl, JCMethodDecl>> methods = defaultMethods.get(type.sym);
-		if (methods == null) {
-			methods = new HashSet<>();
-			defaultMethods.put(type.sym, methods);
-		}
+		Set<Entry<JCClassDecl, JCMethodDecl>> methods = defaultMethods.computeIfAbsent(type.sym, k -> new HashSet<>());
 		methods.add(new AbstractMap.SimpleEntry<>(type, defaultMethod));
 		defaultMethodsCompilationUnits.put(defaultMethod, compilationUnit);
 	}

--- a/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
@@ -2053,9 +2053,9 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 	 */
 	@Override
 	public void visitMethodDef(JCMethodDecl methodDecl) {
-
-		if (context.hasAnnotationType(methodDecl.sym, JSweetConfig.ANNOTATION_ERASED)) {
-			// erased elements are ignored
+		if (context.hasAnnotationType(methodDecl.sym, JSweetConfig.ANNOTATION_ERASED) ||
+				(context.hasAnnotationType(methodDecl.sym, JSweetConfig.ANNOTATION_INLINED) && methodDecl.params.size() == 0)) {
+			// erased and inlined elements are ignored
 			return;
 		}
 

--- a/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
@@ -2054,7 +2054,7 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 	@Override
 	public void visitMethodDef(JCMethodDecl methodDecl) {
 		if (context.hasAnnotationType(methodDecl.sym, JSweetConfig.ANNOTATION_ERASED) ||
-				(context.hasAnnotationType(methodDecl.sym, JSweetConfig.ANNOTATION_INLINED) && methodDecl.params.size() == 0)) {
+				context.hasAnnotationType(methodDecl.sym, JSweetConfig.ANNOTATION_INLINE)) {
 			// erased and inlined elements are ignored
 			return;
 		}
@@ -2481,13 +2481,13 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 	 * Print async keyword for given method if relevant. Prints nothing if method
 	 * shouldn't be async
 	 */
-	protected void printAsyncKeyword(JCMethodDecl methodDecl) {
+	public void printAsyncKeyword(JCMethodDecl methodDecl) {
 		if (getScope().declareClassScope) {
 			return;
 		}
 
 		if (context.hasAnnotationType(methodDecl.sym, JSweetConfig.ANNOTATION_ASYNC)) {
-			print(" async ");
+			print("async ");
 		}
 	}
 

--- a/transpiler/src/main/java/org/jsweet/transpiler/extension/Java2TypeScriptAdapter.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/extension/Java2TypeScriptAdapter.java
@@ -347,14 +347,20 @@ public class Java2TypeScriptAdapter extends PrinterAdapter {
 
 
 		if (hasAnnotationType(method, ANNOTATION_INLINE)) {
-
 			if (invocationElement instanceof ExtendedElementSupport) {
-				JCTree tree = ((ExtendedElementSupport) invocationElement).getTree();
 				// check recurse
 				Stack<JCTree> stack = getPrinter().getStack();
 				for (int i = 0; i < stack.size() - 1; i++) {
-					if (stack.get(i).equals(tree)) {
-						print("($$INLINED$$").print(targetType.getSimpleName()).print("$").print(method.getSimpleName());
+					JCTree jcTree = stack.get(i);
+					MethodInvocationElement prev;
+					if (jcTree instanceof JCMethodInvocation &&
+							(prev = new MethodInvocationElementSupport((JCMethodInvocation)jcTree)).getMethod().equals(method)) {
+						Element prevTargetType = prev.getMethod().getEnclosingElement();
+						if (invocationElement.getTargetExpression() != null) {
+							prevTargetType = invocationElement.getTargetExpression().getTypeAsElement();
+						}
+
+						print("($$INLINED$$").print(prevTargetType.getSimpleName()).print("$").print(method.getSimpleName());
 						print(".call(");
 						if (invocationElement.getTargetExpression() != null) {
 							print(invocationElement.getTargetExpression());

--- a/transpiler/src/main/java/org/jsweet/transpiler/extension/Java2TypeScriptAdapter.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/extension/Java2TypeScriptAdapter.java
@@ -390,8 +390,9 @@ public class Java2TypeScriptAdapter extends PrinterAdapter {
 				print("$$INLINED$$").print(targetType.getSimpleName()).print("$").print(method.getSimpleName());
 				print("(");
 				for (JCTree.JCVariableDecl param : inlinedMethod.params) {
-					print(context.getActualName(param.sym) + ", ");
+					getPrinter().print(param.name.toString()).print(" : ").print(param.vartype).print(", ");
 				}
+
 				if (!inlinedMethod.params.isEmpty()) {
 					removeLastChars(2);
 				}


### PR DESCRIPTION
This Idea comes from the previous #452 PR, but in general.

@ Inline is an annotation which tells jsweet to force inline the function body to the caller target.
 This means these functions are not exist, but can be use them as any other function in same compilation unit, without limitations.

Example:
```
package java;

import jsweet.lang.Inline;

import static def.dom.Globals.console;

public class Test {
    private static int result = 0;
    public static void main(String[] args) {
        console.info(multiple(20, 13));
    }

    @Inline
    public static int multiple(int first, int second) {
        result = first;
        for (int i = 1; i < second; ++i) {
            result = add(result, first);
        }
        return result;
    }

    @Inline
    public static int add(int first, int second) {
        if (second > 0) {
            return add(first + 1, second - 1);
        } else if (second < 0) {
            return add(first - 1, second + 1);
        } else {
            return first;
        }
    }
}
```
compiles to:
```
namespace java {
    export class Test {
        static result : number = 0;

        public static main(args : string[]) {
            console.info(((function $$INLINED$$Test$multiple(first : number, second : number) {
                Test.result = first;
                for(let i : number = 1; i < second; ++i) {
                    Test.result = ((function $$INLINED$$Test$add(first : number, second : number) {
                        if(second > 0) {
                            return ($$INLINED$$Test$add.call(this, first + 1, second - 1));
                        } else if(second < 0) {
                            return ($$INLINED$$Test$add.call(this, first - 1, second + 1));
                        } else {
                            return first;
                        }
                    }).call(this, Test.result, first));
                };
                return Test.result;
            }).call(this, 20, 13)));
        }
    }
    Test["__class"] = "java.Test";

}
```

I [hide](https://github.com/cincheo/jsweet/compare/master...schaumb:patch-2?expand=1#diff-031be2405393703e0cff0db57e8d26fdR378) a Promise specific feature, which enables to return a non-Promise object from an async function.
If a function annotated with @ Inline and @ Async, and if the result type is not Promise, then the inlined function got a "await" prefix.


Example
```
package java;

import def.js.Promise;
import jsweet.lang.Async;
import jsweet.lang.Inline;
import jsweet.util.Lang;

import java.util.function.Function;

import static def.dom.Globals.console;
import static jsweet.util.Lang.await;

public class Test {
    private static Promise<Integer> result = Promise.resolve(0);
    public static void main(String[] args) {
        console.info(multiple(Promise.resolve(20), Promise.resolve(13)));
    }

    @Inline
    @Async
    public static Promise<Integer> multiple(Promise<Integer> first, Promise<Integer> second) {
        result = first;
        int sec = await(second);
        for (int i = 1; i < sec; ++i) {
            int res = add(result, first);
            result = Promise.resolve(res);
        }
        return result;
    }

    @Inline
    @Async
    public static Integer add(Promise<Integer> i1, Promise<Integer> i2) {
        return await(Promise.all(Lang.<Promise.IterablePromiseLikeT<Integer>> any(new Promise[]{i1, i2}))
                .then((Function<Integer[], Integer>) (Integer[] iArr) -> {
                    if (iArr[1] > 0) {
                        return add(Promise.resolve(iArr[0] + 1), Promise.resolve(iArr[1] - 1));
                    } else if (iArr[1] < 0) {
                        return add(Promise.resolve(iArr[0] - 1), Promise.resolve(iArr[1] + 1));
                    } else
                        return iArr[0];
                }));
    }
}
```
to
```
namespace java {
    export class Test {
        static result : Promise<number>; public static result_$LI$() : Promise<number> { if(Test.result == null) Test.result = Promise.resolve(0); return Test.result; };

        public static main(args : string[]) {
            console.info(((async function $$INLINED$$Test$multiple(first : Promise<number>, second : Promise<number>) {
                Test.result = first;
                let sec : number = <any>(await second);
                for(let i : number = 1; i < sec; ++i) {
                    let res : number = (await (async function $$INLINED$$Test$add(i1 : Promise<number>, i2 : Promise<number>) {
                        return <any>(await Promise.all(<any>((<any>([i1, i2])))).then(<any>((iArr) => {
                            if(iArr[1] > 0) {
                                return ($$INLINED$$Test$add.call(this, Promise.resolve(iArr[0] + 1), Promise.resolve(iArr[1] - 1)));
                            } else if(iArr[1] < 0) {
                                return ($$INLINED$$Test$add.call(this, Promise.resolve(iArr[0] - 1), Promise.resolve(iArr[1] + 1)));
                            } else return iArr[0];
                        })));
                    }).call(this, Test.result_$LI$(), first));
                    Test.result = Promise.resolve(res);
                };
                return Test.result_$LI$();
            }).call(this, Promise.resolve(20), Promise.resolve(13))));
        }
    }
    Test["__class"] = "java.Test";

}
```