### PR TITLE
main() got real arguments

### DIFF
--- a/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
@@ -1994,7 +1994,8 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 			context.entryFiles.add(new File(compilationUnit.sourcefile.getName()));
 			context.addFooterStatement(mainMethodQualifier + JSweetConfig.MAIN_FUNCTION_NAME + "("
 					+ (getScope().mainMethod.getParameters().isEmpty() ? "" :
-					"(this.document && this.document.currentScript && this.document.currentScript['src'] ? new URL(this.document.currentScript['src']) : this.location !== undefined ? this.location : { 'search': '' })" +
+					"this.process && this.process.argv ? this.process.argv.slice(2) : " +
+					"(this.document && this.document.currentScript && this.document.currentScript['src'] ? new URL(this.document.currentScript['src']) : this.location ? this.location : { 'search': '' })" +
 							".search.substr(1).split('&')" +
 							".map(s => s.length == 0 ? s : s.indexOf('=') > 1 || (s.indexOf('=') == -1 && s.length > 1) ? '--'+s : '-'+s.split(/=(.+)/).join(''))")
 					+ ");");

--- a/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
@@ -1993,7 +1993,11 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 			}
 			context.entryFiles.add(new File(compilationUnit.sourcefile.getName()));
 			context.addFooterStatement(mainMethodQualifier + JSweetConfig.MAIN_FUNCTION_NAME + "("
-					+ (getScope().mainMethod.getParameters().isEmpty() ? "" : "null") + ");");
+					+ (getScope().mainMethod.getParameters().isEmpty() ? "" :
+					"(document && document.currentScript && document.currentScript['src'] ? new URL(document.currentScript['src']) : self.location)" +
+							".search.substr(1).split('&')" +
+							".map(s => s.length == 0 ? s : s.indexOf('=') > 1 || (s.indexOf('=') == -1 && s.length > 1) ? '--'+s : '-'+s.split(/=(.+)/).join(' '))")
+					+ ");");
 		}
 
 		getAdapter().typeVariablesToErase.removeAll(parentTypeVars);

--- a/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
@@ -1994,7 +1994,7 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 			context.entryFiles.add(new File(compilationUnit.sourcefile.getName()));
 			context.addFooterStatement(mainMethodQualifier + JSweetConfig.MAIN_FUNCTION_NAME + "("
 					+ (getScope().mainMethod.getParameters().isEmpty() ? "" :
-					"(document && document.currentScript && document.currentScript['src'] ? new URL(document.currentScript['src']) : self.location)" +
+					"(this.document && this.document.currentScript && this.document.currentScript['src'] ? new URL(this.document.currentScript['src']) : this.location !== undefined ? this.location : { 'search': '' })" +
 							".search.substr(1).split('&')" +
 							".map(s => s.length == 0 ? s : s.indexOf('=') > 1 || (s.indexOf('=') == -1 && s.length > 1) ? '--'+s : '-'+s.split(/=(.+)/).join(''))")
 					+ ");");

--- a/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
@@ -1996,7 +1996,7 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 					+ (getScope().mainMethod.getParameters().isEmpty() ? "" :
 					"(document && document.currentScript && document.currentScript['src'] ? new URL(document.currentScript['src']) : self.location)" +
 							".search.substr(1).split('&')" +
-							".map(s => s.length == 0 ? s : s.indexOf('=') > 1 || (s.indexOf('=') == -1 && s.length > 1) ? '--'+s : '-'+s.split(/=(.+)/).join(' '))")
+							".map(s => s.length == 0 ? s : s.indexOf('=') > 1 || (s.indexOf('=') == -1 && s.length > 1) ? '--'+s : '-'+s.split(/=(.+)/).join(''))")
 					+ ");");
 		}
 


### PR DESCRIPTION
This modification about main function (String[]) arguments.
So far it called with null. From now the script parameters (URL serach part) transformed to standard unix formatted command line arguments.
If we are in a (.js) script, the loading script arguments, else the site arguments are used

examples:
`http://example.com/xy.js`
`[]`

`'http://example.com/xy.js?#noonecares'`
`[]`

`'http://example.com/?works'`
`["--works"]`

`'http://example.com/xy.js?a=6&b&&longc=44&longd'`
`["-a6", "-b", "", "--longc=44", "--longd"]`

