### PR TITLE
Return removed value in the maps remove macro

### DIFF
--- a/transpiler/src/main/java/org/jsweet/transpiler/extension/RemoveJavaDependenciesAdapter.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/extension/RemoveJavaDependenciesAdapter.java
@@ -983,9 +983,14 @@ public class RemoveJavaDependenciesAdapter extends Java2TypeScriptAdapter {
 				return true;
 			case "remove":
 				printMacroName(targetMethodName);
+				print("(map => { let deleted = ");
+				print(invocation.getTargetExpression(), delegate).print("[").print(invocation.getArgument(0))
+						.print("];");
 				print("delete ");
 				print(invocation.getTargetExpression(), delegate).print("[").print(invocation.getArgument(0))
-						.print("]");
+						.print("];");
+				print("return deleted;})").print("(");
+				print(invocation.getTargetExpression(), delegate).print(")");
 				return true;
 			case "clear":
 				printMacroName(targetMethodName);

--- a/transpiler/src/test/java/org/jsweet/test/transpiler/NativeStructuresTests.java
+++ b/transpiler/src/test/java/org/jsweet/test/transpiler/NativeStructuresTests.java
@@ -109,7 +109,7 @@ public class NativeStructuresTests extends AbstractTest {
 	public void testMaps() {
 		eval((logHandler, result) -> {
 			Assert.assertEquals("There should be no errors", 0, logHandler.reportedProblems.size());
-			assertEquals("1,a,2,b,2,a,true,[1, 2],[a, b],1,true,size2=2,1,2,[],empty=true,-null-,1,a,2,b",
+			assertEquals("1,a,2,b,2,a,true,[1, 2],[a, b],a,1,true,size2=2,1,2,[],empty=true,-null-,1,a,2,b",
 					result.get("trace"));
 		}, getSourceFile(Maps.class));
 	}

--- a/transpiler/src/test/java/source/nativestructures/Maps.java
+++ b/transpiler/src/test/java/source/nativestructures/Maps.java
@@ -47,8 +47,9 @@ public class Maps {
 
 		Map<String, String> m2 = (Map) m.clone();
 		
-		m.remove("1");
+		String removed = m.remove("1");
 
+		trace.push(removed);
 		trace.push("" + m.size());
 		trace.push("" + (m.get("1") == null));
 		


### PR DESCRIPTION
A simple fix that makes the native Map `remove` implementation closer to the JDK one.