### PR TITLE
Type mapping and @Erased ignored in some cases

### DIFF
--- a/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
@@ -640,6 +640,10 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 				importedClass);
 	}
 
+	private boolean isMappedOrErasedType(Symbol symbol) {
+		return context.isMappedType(symbol.type.tsym.toString()) || context.hasAnnotationType(symbol, JSweetConfig.ANNOTATION_ERASED);
+	}
+
 	/**
 	 * Prints a compilation unit tree.
 	 */
@@ -781,7 +785,7 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 				private HashSet<String> names = new HashSet<>();
 
 				private void checkType(TypeSymbol type) {
-					if (type instanceof ClassSymbol) {
+					if (type instanceof ClassSymbol && !isMappedOrErasedType(type)) {
 						String name = type.getSimpleName().toString();
 						if (!names.contains(name)) {
 							names.add(name);
@@ -1700,7 +1704,7 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 			methods.sort((m1, m2) -> m1.getSimpleName().compareTo(m2.getSimpleName()));
 			Map<Name, String> signatures = new HashMap<>();
 			for (MethodSymbol meth : methods) {
-				if (meth.type instanceof MethodType) {
+				if (meth.type instanceof MethodType && !context.hasAnnotationType(meth, JSweetConfig.ANNOTATION_ERASED) && !isMappedOrErasedType(meth.owner)) {
 					// do not generate default abstract method for already
 					// generated methods
 					if (getScope().generatedMethodNames.contains(meth.name.toString())) {
@@ -2914,7 +2918,7 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 	}
 
 	private void checkType(TypeSymbol type) {
-		if (type instanceof ClassSymbol) {
+		if (type instanceof ClassSymbol && !isMappedOrErasedType(type)) {
 			String name = type.getSimpleName().toString();
 			ModuleImportDescriptor moduleImport = getModuleImportDescriptor(name, (ClassSymbol) type);
 			if (moduleImport != null) {

--- a/transpiler/src/test/java/source/extension/AbstractClassWithBigDec.java
+++ b/transpiler/src/test/java/source/extension/AbstractClassWithBigDec.java
@@ -1,0 +1,7 @@
+package source.extension;
+
+import java.math.BigDecimal;
+
+public abstract class AbstractClassWithBigDec implements IAddNumber {
+    BigDecimal a = new BigDecimal(0);
+}

--- a/transpiler/src/test/java/source/extension/IAddNumber.java
+++ b/transpiler/src/test/java/source/extension/IAddNumber.java
@@ -1,0 +1,5 @@
+package source.extension;
+
+public interface IAddNumber {
+    int addNumber(int number);
+}


### PR DESCRIPTION
Fix for the following issue:
Type mapping and @Erased annotation ignored #479
The following has changed:
* imports are not included anymore if the imported class is erased by `@Erased` or  mapped to a different type.
* interface methods are not automatically added to an abstract class if the interface is mapped to a different type or is annotated with `@Erased`

The `@Module` annotation still works even if the referenced import is mapped or erased.
All test passed on my local machine.
Hope this fix does not limit other use cases:)