### PR TITLE
header missing for default method accessing superclass enum #530

### DIFF
--- a/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
@@ -4047,6 +4047,13 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 						String rootRelativeName = getRootRelativeName(clazz.getEnclosingElement());
 						if (!rootRelativeName.isEmpty()) {
 							print(rootRelativeName + ".");
+							PackageSymbol identifierPackage = clazz.packge();
+							String pathToModulePackage = Util.getRelativePath(compilationUnit.packge, identifierPackage);
+							if (pathToModulePackage == null) {
+								pathToModulePackage = ".";
+							}
+							File moduleFile = new File(new File(pathToModulePackage), clazz.owner.getSimpleName().toString());
+							useModule(false, identifierPackage, ident, clazz.owner.getSimpleName().toString(), moduleFile.getPath().replace('\\', '/'), null);
 						}
 						prefixAdded = true;
 					}


### PR DESCRIPTION
I pushed a fix that so far works for my code but I suspect that the header inclusion should happen at another place or that it might not work for all cases.
#530