### PR TITLE
Support Map initialization via non-Map arguments

### DIFF
--- a/transpiler/src/main/java/org/jsweet/transpiler/extension/RemoveJavaDependenciesAdapter.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/extension/RemoveJavaDependenciesAdapter.java
@@ -67,6 +67,7 @@ import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 
+import com.sun.tools.javac.code.Type;
 import org.jsweet.transpiler.JSweetContext;
 import org.jsweet.transpiler.Java2TypeScriptTranslator;
 import org.jsweet.transpiler.ModuleKind;
@@ -1526,7 +1527,11 @@ public class RemoveJavaDependenciesAdapter extends Java2TypeScriptAdapter {
 		case "java.util.Hashtable":
 		case "java.util.WeakHashMap":
 		case "java.util.LinkedHashMap":
-			if (newClass.getArgumentCount() == 0) {
+			if (newClass.getArgumentCount() == 0 ||
+                !(newClass.getArgument(0).getType() instanceof Type.ClassType) ||
+				!Util.isDeclarationOrSubClassDeclaration(
+                	types(), (Type.ClassType) newClass.getArgument(0).getType(), Map.class.getName())
+			) {
 				print("{}");
 			} else {
 				if (((DeclaredType) newClass.getType()).getTypeArguments().size() == 2 && types().isSameType(

--- a/transpiler/src/test/java/source/nativestructures/Maps.java
+++ b/transpiler/src/test/java/source/nativestructures/Maps.java
@@ -2,7 +2,9 @@ package source.nativestructures;
 
 import static jsweet.util.Lang.$export;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -118,7 +120,20 @@ public class Maps {
 		assert m8.containsKey(3);
 		assert m7.containsKey(1);
 		assert !m7.containsKey(3);
-		
+
+		for (Map<String, Integer> map : Arrays.<Map<String, Integer>>asList(
+				new HashMap<>(10),
+                new HashMap<>(10, 11),
+				new TreeMap<>(Comparator.comparingInt(String::hashCode))
+		)) {
+			map.put("a", 1);
+			map.put("b", 2);
+			assert map.size() == 2;
+			assert map.get("a") == 1;
+			assert map.get("b") == 2;
+			assert map.get("c") == null;
+		}
+
 		$export("trace", trace.join(","));
 
 	}


### PR DESCRIPTION
This patch ignores any arguments that isn't of Map type during
the invocation of a Map collection. Based on the supported
data-structures, these non-Map arguments can either be of type
int (capacity, loadFactor) or Comparator. The use case for the
latter is not currently supported while the former have no equivalent
in javascript.

Fixes #508