### PR TITLE
Add support for transpiling collections to ES6

### DIFF
--- a/transpiler/src/main/java/org/jsweet/transpiler/extension/RemoveJavaDependenciesAdapter.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/extension/RemoveJavaDependenciesAdapter.java
@@ -110,7 +110,12 @@ public class RemoveJavaDependenciesAdapter extends Java2TypeScriptAdapter {
 		init();
 	}
 
-	private void init() {
+	protected void init() {
+	    initTypesMapping();
+		addTypeMappings(extTypesMapping);
+    }
+
+	protected void initTypesMapping() {
 		addTypeMapping(Class.class.getName(), "any");
 		context.getLangTypeMappings().put(RuntimeException.class.getName(), "Error");
 		context.getBaseThrowables().add(RuntimeException.class.getName());
@@ -161,7 +166,6 @@ public class RemoveJavaDependenciesAdapter extends Java2TypeScriptAdapter {
 
 		extTypesMapping.put(Method.class.getName(), "{ owner: any, name: string, fn : Function }");
 
-		addTypeMappings(extTypesMapping);
 		addTypeMapping(
 				(typeTree,
 						name) -> name.startsWith("java.")

--- a/transpiler/src/main/java/org/jsweet/transpiler/extension/RemoveJavaDependenciesES6Adapter.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/extension/RemoveJavaDependenciesES6Adapter.java
@@ -1,0 +1,229 @@
+/*
+ * JSweet transpiler - http://www.jsweet.org
+ * Copyright (C) 2019 CINCHEO SAS <renaud.pawlak@cincheo.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.jsweet.transpiler.extension;
+
+import java.util.AbstractSet;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.jsweet.transpiler.JSweetProblem;
+import org.jsweet.transpiler.model.ExtendedElement;
+import org.jsweet.transpiler.model.MethodInvocationElement;
+import org.jsweet.transpiler.model.NewClassElement;
+
+/**
+ * An adapter that removes many uses of Java APIs and replace them with
+ * JavaScript ES6 equivalent when possible.
+ */
+
+public class RemoveJavaDependenciesES6Adapter extends RemoveJavaDependenciesAdapter {
+    private Set<String> setClassNames = Stream.of(
+            Set.class, HashSet.class, LinkedHashSet.class, TreeSet.class, AbstractSet.class)
+            .map(Class::getName)
+            .collect(Collectors.toSet());
+
+    public RemoveJavaDependenciesES6Adapter(PrinterAdapter parentAdapter) {
+        super(parentAdapter);
+    }
+
+    @Override
+    protected void initTypesMapping() {
+        setClassNames = Stream.of(Set.class, HashSet.class, AbstractSet.class)
+            .map(Class::getName)
+            .collect(Collectors.toSet());
+
+        super.initTypesMapping();
+        setClassNames.forEach(name -> extTypesMapping.put(name, "any"));
+    }
+
+    @Override
+    protected RemoveJavaDependenciesES6Adapter print(ExtendedElement expression, boolean delegate) {
+        super.print(expression, delegate);
+        return this;
+    }
+
+    @Override
+    protected RemoveJavaDependenciesES6Adapter printTargetForParameter(ExtendedElement expression, boolean delegate) {
+        super.printTargetForParameter(expression, delegate);
+        return print(expression, delegate);
+    }
+
+    @Override
+    public boolean substituteNewClass(NewClassElement newClass) {
+        String className = newClass.getTypeAsElement().toString();
+
+        if (setClassNames.contains(className)) {
+            this.substituteNewSet(newClass);
+            return true;
+        }
+
+        return super.substituteNewClass(newClass);
+    }
+
+    private void substituteNewSet(NewClassElement newClass) {
+        boolean ignoreArguments = newClass.getArgumentCount() == 0 ||
+                Integer.class.getName().equals(newClass.getArgument(0).getType().toString()) ||
+                "int".equals(newClass.getArgument(0).getType().toString());
+
+        if (ignoreArguments) {
+            print(String.format(
+                    "(() => { const col = %s; col.data = new Set(); col.iterator = %s; return col; })()",
+                    createNewCollection(newClass.getType().toString()),
+                    "() => { let i = 0; const a = Array.from(col.data.values()); return { next: () => i < a.length? a[i++] : null, hasNext: () => i < a.length }; }"
+            ));
+        } else {
+            print(String.format(
+                    "((arg) => { const col = %s; col.data = new Set(); col.iterator = %s; %s return col; })(",
+                    createNewCollection(newClass.getType().toString()),
+                    "() => { let i = 0; const a = Array.from(col.data.values()); return { next: () => i < a.length? a[i++] : null, hasNext: () => i < a.length }; }",
+                    "const it = arg.iterator(); while(it.hasNext()) col.data.add(it.next());"
+            )).print(newClass.getArgument(0)).print(")");
+        }
+    }
+
+    @Override
+    public boolean substituteMethodInvocation(MethodInvocationElement invocation) {
+        String targetClassName = invocation.getMethod().getEnclosingElement().toString();
+        ExtendedElement targetExpression = invocation.getTargetExpression();
+        if (targetExpression != null) {
+            targetClassName = targetExpression.getTypeAsElement().toString();
+        }
+
+        if (setClassNames.contains(targetClassName)) {
+            this.substituteMethodOnSet(invocation);
+            return true;
+        }
+
+        return super.substituteMethodInvocation(invocation);
+    }
+
+    private void substituteMethodOnSet(MethodInvocationElement invocation) {
+        String targetMethodName = invocation.getMethodName();
+        ExtendedElement targetExpression = invocation.getTargetExpression();
+
+        switch (targetMethodName) {
+            case "add":
+                printMacroName(targetMethodName);
+                print("((s, v) => { const n = s.data.size; s.data.add(v); return n !== s.data.size; })(")
+                        .print(targetExpression)
+                        .print(",")
+                        .print(invocation.getArgument(0))
+                        .print(")");
+                break;
+            case "addAll":
+                printMacroName(targetMethodName);
+                print("((s, c) => { const it = c.iterator(); const n = s.data.size; while(it.hasNext()) s.data.add(it.next()); return n !== s.data.size; })(")
+                        .print(targetExpression)
+                        .print(",")
+                        .print(invocation.getArgument(0))
+                        .print(")");
+                break;
+            case "clear":
+                printMacroName(targetMethodName);
+                print(targetExpression)
+                        .print(".data.clear()");
+                break;
+            case "contains":
+                printMacroName(targetMethodName);
+                print(targetExpression)
+                        .print(".data.has(")
+                        .print(invocation.getArgument(0))
+                        .print(")");
+                break;
+            case "containsAll":
+                printMacroName(targetMethodName);
+                print("((s, c) => { const it = c.iterator(); while(it.hasNext()) if (!s.has(it.next())) return false; return true; })(")
+                        .print(targetExpression)
+                        .print(",")
+                        .print(invocation.getArgument(0))
+                        .print(")");
+                break;
+            case "equals":
+                printMacroName(targetMethodName);
+                print("((s1, s2) => { if (!s1 || !s2) return s1 === s2; const it1 = s1.iterator(); const it2 = s2.iterator(); while(it1.hasNext()) if (it1.next() !== it2.next()) return false; return !it2.hasNext(); })(")
+                        .print(targetExpression)
+                        .print(",")
+                        .print(invocation.getArgument(0))
+                        .print(")");
+                break;
+            case "hashCode":
+                printMacroName(targetMethodName);
+                report(invocation, JSweetProblem.USER_ERROR, "hashCode() is not supported.");
+                break;
+            case "isEmpty":
+                printMacroName(targetMethodName);
+                print("(")
+                        .print(targetExpression)
+                        .print(".data.size === 0")
+                        .print(")");
+                break;
+            case "iterator":
+                printMacroName(targetMethodName);
+                print(targetExpression).print(".iterator()");
+                break;
+            case "remove":
+                printMacroName(targetMethodName);
+                print("(")
+                        .print(targetExpression)
+                        .print(".data.delete(")
+                        .print(invocation.getArgument(0))
+                        .print(")")
+                        .print(")");
+                break;
+            case "removeAll":
+                    printMacroName(targetMethodName);
+                    print("((s, c) => { const it = c.iterator(); const n = s.data.size; while (it.hasNext()) s.data.delete(it.next()); return n !== s.data.size; })(")
+                            .print(targetExpression)
+                            .print(",")
+                            .print(invocation.getArgument(0))
+                            .print(")");
+                    break;
+            case "retainAll":
+                printMacroName(targetMethodName);
+                print("((s, c) => { const n = s.data.size; const s2 = new Set(); const it = c.iterator(); while(it.hasNext()) s2.add(it.next()); s.data.forEach(v => { if(!s2.has(v)) s.data.delete(v); }); return n !== s.data.size; })(")
+                        .print(targetExpression)
+                        .print(",")
+                        .print(invocation.getArgument(0))
+                        .print(")");
+                break;
+            case "size":
+                printMacroName(targetMethodName);
+                print(targetExpression).print(".data.size");
+                break;
+            case "toArray":
+                printMacroName(targetMethodName);
+                print("(")
+                        .print("Array.from(")
+                        .print(targetExpression)
+                        .print(".data)")
+                        .print(")");
+                break;
+            default:
+                report(invocation, JSweetProblem.USER_ERROR, targetMethodName + " is not supported.");
+        }
+    }
+
+    private String createNewCollection(String className) {
+        return String.format("{ className: '%s', data: null, iterator: null }", className);
+    }
+}

--- a/transpiler/src/test/java/org/jsweet/test/transpiler/NativeStructuresTests.java
+++ b/transpiler/src/test/java/org/jsweet/test/transpiler/NativeStructuresTests.java
@@ -9,6 +9,7 @@ import org.jsweet.transpiler.JSweetFactory;
 import org.jsweet.transpiler.ModuleKind;
 import org.jsweet.transpiler.extension.PrinterAdapter;
 import org.jsweet.transpiler.extension.RemoveJavaDependenciesAdapter;
+import org.jsweet.transpiler.extension.RemoveJavaDependenciesES6Adapter;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -16,6 +17,7 @@ import org.junit.Test;
 import source.nativestructures.ArraysSort;
 import source.nativestructures.Collections;
 import source.nativestructures.Dates;
+import source.nativestructures.ES6Sets;
 import source.nativestructures.Exceptions;
 import source.nativestructures.ExtendsJDK;
 import source.nativestructures.ExtendsJDKAnonymous;
@@ -75,6 +77,19 @@ public class NativeStructuresTests extends AbstractTest {
 		eval((logHandler, result) -> {
 			logHandler.assertNoProblems();
 		}, getSourceFile(Sets.class));
+	}
+
+	@Test
+	public void testES6Sets() {
+		TranspilerTestRunner transpilerTest = new TranspilerTestRunner(getCurrentTestOutDir(), new JSweetFactory() {
+			@Override
+			public PrinterAdapter createAdapter(JSweetContext context) {
+				return new RemoveJavaDependenciesES6Adapter(super.createAdapter(context));
+			}
+		});
+		transpilerTest.eval((logHandler, result) -> {
+			logHandler.assertNoProblems();
+		}, getSourceFile(ES6Sets.class));
 	}
 
 	@Test

--- a/transpiler/src/test/java/source/nativestructures/ES6Sets.java
+++ b/transpiler/src/test/java/source/nativestructures/ES6Sets.java
@@ -1,0 +1,141 @@
+package source.nativestructures;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ES6Sets {
+    public static void main(String[] args) {
+        // add
+        Set s1 = new HashSet();
+        assert s1.size() == 0;
+        boolean added = s1.add("1");
+        assert added;
+        s1.add("2");
+        boolean added2 = s1.add("2");
+        assert !added2;
+        assert s1.size() == 2;
+        s1.clear();
+        assert s1.size() == 0;
+
+        // remove
+        Set<String> s2 = new HashSet<>();
+        s2.add("1");
+        assert s2.size() == 1;
+        assert s2.remove("1");
+        assert s2.size() == 0;
+        s2.add("2");
+        assert !s2.remove("1");
+        assert s2.size() == 1;
+        assert !s2.isEmpty();
+
+        Set<Integer> s3 = new HashSet<>();
+        s3.add(1);
+        assert s3.size() == 1;
+        assert s3.remove(1);
+        assert s3.size() == 0;
+        s3.add(2);
+        assert !s3.remove(1);
+        assert s3.size() == 1;
+
+        // contains
+        Set<String> s4A = new HashSet<>();
+        Set<String> s4B = new HashSet<>();
+        Set<String> s4C = new HashSet<>();
+        Set<Set<String>> s4 = new HashSet<>();
+        s4.add(s4A);
+        s4.add(s4B);
+        assert s4.size() == 2;
+        assert s4.contains(s4A);
+        assert s4.contains(s4B);
+        assert !s4.contains(s4C);
+
+        // addAll
+        Set<String> s5A = new HashSet<>();
+        s5A.add("1");
+        s5A.add("2");
+        Set<String> s5B = new HashSet<>();
+        s5B.add("3");
+        s5B.add("4");
+        Set<String> s5Merged = new HashSet<>();
+        boolean addedAll = s5Merged.addAll(s5A);
+        assert addedAll;
+        s5Merged.addAll(s5B);
+        assert s5Merged.size() == 4;
+        for (int i = 1; i <= 4; i++) {
+            assert s5Merged.contains("" + i);
+        }
+
+        // new HashSet(Collection<>);
+        Set<String> s6A = new HashSet<>();
+        s6A.add("1");
+        s6A.add("2");
+        Set<String> s6 = new HashSet<>(s6A);
+        assert s6.size() == 2;
+        for (int i = 1; i <= 2; i++) {
+            assert s6.contains("" + i);
+        }
+
+        // new HashSet(int initialCapacity);
+        Set<String> s7 = new HashSet<>(10);
+        assert s7.size() == 0;
+        assert s7.isEmpty();
+
+        // new HashSet(int initialCapacity, float loadFactor);
+        Set<String> s8 = new HashSet<>(10, 11);
+        assert s8.size() == 0;
+        assert s8.isEmpty();
+
+        // removeAll
+        Set<String> s9A = new HashSet<>();
+        s9A.add("1");
+        s9A.add("3");
+        s9A.add("5");
+        s9A.add("7");
+        Set<String> s9 = new HashSet<>();
+        s9.add("1");
+        s9.add("2");
+        s9.add("3");
+        s9.add("4");
+        s9.add("5");
+        assert s9.size() == 5;
+        boolean removedAll = s9.removeAll(s9A);
+        assert removedAll;
+        assert s9.size() == 2;
+        assert s9.contains("2");
+        assert !s9.contains("3");
+        assert s9.contains("4");
+
+        // retainAll
+        Set<String> s10A = new HashSet<>();
+        s10A.add("1");
+        s10A.add("3");
+        s10A.add("5");
+        s10A.add("7");
+        Set<String> s10 = new HashSet<>();
+        s10.add("1");
+        s10.add("2");
+        s10.add("3");
+        s10.add("4");
+        s10.add("5");
+        assert s10.size() == 5;
+        boolean retainedAll = s10.retainAll(s10A);
+        assert retainedAll;
+        assert s10.size() == 3;
+        assert s10.contains("1");
+        assert !s10.contains("2");
+        assert s10.contains("3");
+        assert !s10.contains("4");
+        assert s10.contains("5");
+        assert !s10.contains("7");
+
+        // toArray
+        Set<String> s11 = new HashSet<>();
+        s11.add("1");
+        s11.add("2");
+        String[] ar = (String[]) s11.toArray();
+        assert ar.length == 2;
+        assert "1".equals(ar[0]) || "2".equals(ar[0]);
+        assert "1".equals(ar[1]) || "2".equals(ar[1]);
+        assert !ar[0].equals(ar[1]);
+    }
+}


### PR DESCRIPTION
This commit adds an Adapter that transpiles sets using ES6 Set
implementation.
The goal of the adapter is to use a standard API for the transpiled
collections in order to abstract implementation details of collections
as well as enable
inter-operability between collections just as in Java.
For example in Java most collections can be initialized with any
arbitrary collection and never need to know how that collection is
implemented.

Having the transpiled code work only via the API at collection
boundaries enables this.
However this means that collections transpiled by this adapter are not
compatible with those transpiled by other adapters - this should be less
of an issue once the adapter has support to handle all collection types.

Related #548
Fixes #549