### PR TITLE
fix dependent fields initialization

### DIFF
--- a/transpiler/pom.xml
+++ b/transpiler/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jsweet</groupId>
 	<artifactId>jsweet-transpiler</artifactId>
-	<version>2.3.6-SNAPSHOT</version>
+	<version>2.3.7-SNAPSHOT</version>
 	<name>JSweet transpiler</name>
 	<description>A Java to TypeScript/JavaScript Open Transpiler</description>
 	<developers>

--- a/transpiler/src/test/java/org/jsweet/test/transpiler/ApiTests.java
+++ b/transpiler/src/test/java/org/jsweet/test/transpiler/ApiTests.java
@@ -16,6 +16,7 @@
  */
 package org.jsweet.test.transpiler;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -272,7 +273,11 @@ public class ApiTests extends AbstractTest {
 	public void testDates() {
 		eval(ModuleKind.none, (logHandler, r) -> {
 			logHandler.assertNoProblems();
-			Assert.assertEquals("1/1/2020, 1:00:00 AM", r.get("localeString"));
+			assertTrue(asList(
+					"1/1/2020, 1:00:00 AM", 
+					"2020-1-1 1:00:00 AM").contains( 
+					r.get("localeString")));
+			
 		}, getSourceFile(Dates.class));
 	}
 

--- a/transpiler/src/test/java/org/jsweet/test/transpiler/ExtensionTests.java
+++ b/transpiler/src/test/java/org/jsweet/test/transpiler/ExtensionTests.java
@@ -177,7 +177,7 @@ public class ExtensionTests extends AbstractTest {
 		TranspilerTestRunner transpilerExtensionTest = new TranspilerTestRunner(getCurrentTestOutDir(),
 				new TestFactory());
 		transpilerExtensionTest.transpile(ModuleKind.none, (logHandler) -> {
-			Assert.assertEquals("There should be no errors", 0, logHandler.reportedProblems.size());
+			logHandler.assertNoProblems();
 			try {
 				String generated = FileUtils.readFileToString(
 						transpilerExtensionTest.getTranspiler().getContext().sourceFiles[0].getTsFile());

--- a/transpiler/src/test/java/org/jsweet/test/transpiler/InitTests.java
+++ b/transpiler/src/test/java/org/jsweet/test/transpiler/InitTests.java
@@ -33,6 +33,7 @@ import source.init.ConstructorField;
 import source.init.ConstructorFieldInInterface;
 import source.init.ConstructorMethod;
 import source.init.ConstructorMethodInInterface;
+import source.init.DependentFields;
 import source.init.FieldDefaultValues;
 import source.init.Initializer;
 import source.init.InitializerStatementConditionError;
@@ -244,6 +245,15 @@ public class InitTests extends AbstractTest {
 			assertEquals("value:1", result.get("i3"));
 			assertEquals("value:0", result.get("j3"));
 		}, getSourceFile(FieldDefaultValues.class));
+	}
+
+	@Test
+	public void testDependentFields() {
+		eval((logHandler, result) -> {
+			logHandler.assertNoProblems();
+			assertEquals("value:1", result.get("i1"));
+			assertEquals("value:0", result.get("j1"));
+		}, getSourceFile(DependentFields.class));
 	}
 
 	@Test

--- a/transpiler/src/test/java/org/jsweet/test/transpiler/TranspilerTests.java
+++ b/transpiler/src/test/java/org/jsweet/test/transpiler/TranspilerTests.java
@@ -194,7 +194,7 @@ public class TranspilerTests extends AbstractTest {
 				"--jsout", outDir.getPath(), //
 				"--sourceMap", //
 				"-i", gameDir.getAbsolutePath(), //
-				"--excludes", "UselessClass.java:dummy");
+				"--excludes", "UselessClass.java" + File.pathSeparatorChar + "dummy");
 
 		assertTrue(process.exitValue() == 0);
 		files.clear();
@@ -219,7 +219,7 @@ public class TranspilerTests extends AbstractTest {
 				"--sourceMap", //
 				"--factoryClassName", "org.jsweet.transpiler.extension.RemoveJavaDependenciesFactory", //
 				"-i", gameDir.getAbsolutePath(), //
-				"--includes", "UselessClass.java:dummy");
+				"--includes", "UselessClass.java" + File.pathSeparatorChar + "dummy");
 
 		assertTrue(process.exitValue() == 0);
 		files.clear();
@@ -236,7 +236,7 @@ public class TranspilerTests extends AbstractTest {
 				"--sourceMap", //
 				"--factoryClassName", "org.jsweet.transpiler.extension.RemoveJavaDependenciesFactory", //
 				"-i", gameDir.getAbsolutePath(), //
-				"--includes", "UselessClass.java:dummy", "--targetVersion", "ES5");
+				"--includes", "UselessClass.java" + File.pathSeparatorChar + "dummy", "--targetVersion", "ES5");
 
 		assertTrue(process.exitValue() == 0);
 		files.clear();
@@ -253,7 +253,7 @@ public class TranspilerTests extends AbstractTest {
 				"--sourceMap", //
 				"--factoryClassName", "org.jsweet.transpiler.extension.RemoveJavaDependenciesFactory", //
 				"-i", gameDir.getAbsolutePath(), //
-				"--includes", "UselessClass.java:dummy", "--targetVersion", "ES3");
+				"--includes", "UselessClass.java" + File.pathSeparatorChar + "dummy", "--targetVersion", "ES3");
 
 		assertTrue(process.exitValue() == 0);
 		files.clear();
@@ -278,7 +278,7 @@ public class TranspilerTests extends AbstractTest {
 				"--factoryClassName", RemoveJavaDependenciesFactory.class.getName(), //
 				"--sourceMap", //
 				"--verbose", //
-				"-i", sources.map(File::getAbsolutePath).collect(joining(":")));
+				"-i", sources.map(File::getAbsolutePath).collect(joining(File.pathSeparator)));
 
 		assertTrue(process.exitValue() == 0);
 		LinkedList<File> files = new LinkedList<>();
@@ -301,7 +301,7 @@ public class TranspilerTests extends AbstractTest {
 				"--sourceMap", //
 				"--factoryClassName", "org.jsweet.transpiler.extension.RemoveJavaDependenciesFactory", //
 				"-i", gameDir.getAbsolutePath(), //
-				"--includes", "UselessClass.java:dummy", "--targetVersion", "ES4");
+				"--includes", "UselessClass.java" + File.pathSeparatorChar + "dummy", "--targetVersion", "ES4");
 
 		assertTrue(process.exitValue() == 1);
 	}
@@ -476,7 +476,8 @@ public class TranspilerTests extends AbstractTest {
 	public void testConfigurationFile() {
 		SourceFile f = getSourceFile(CanvasDrawing.class);
 		File configurationFile = new File(f.getJavaFile().getParentFile(), "configuration-nobundle.json");
-		TranspilerTestRunner transpilerTest = new TranspilerTestRunner(configurationFile, getCurrentTestOutDir(), new JSweetFactory());
+		TranspilerTestRunner transpilerTest = new TranspilerTestRunner(configurationFile, getCurrentTestOutDir(),
+				new JSweetFactory());
 		assertTrue(transpilerTest.getTranspiler().getHeaderFile().getPath().endsWith("header.txt"));
 		assertFalse(transpilerTest.getTranspiler().isBundle());
 		transpilerTest.transpile(logHandler -> {

--- a/transpiler/src/test/java/source/init/Constructor.java
+++ b/transpiler/src/test/java/source/init/Constructor.java
@@ -27,11 +27,15 @@ public class Constructor {
 	}
 
 	public Constructor(String s) {
+		this(s, false);
+	}
+
+	public Constructor(String s, boolean b) {
 		this.s = s;
 	}
 
 	public static void main(String[] args) {
-		Constructor c = new Constructor("abc");
+		Constructor c = new Constructor("abc", true);
 
 		$export("v1", c.s);
 

--- a/transpiler/src/test/java/source/init/DependentFields.java
+++ b/transpiler/src/test/java/source/init/DependentFields.java
@@ -1,0 +1,44 @@
+/* 
+ * JSweet - http://www.jsweet.org
+ * Copyright (C) 2015 CINCHEO SAS <renaud.pawlak@cincheo.fr>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package source.init;
+
+import static jsweet.util.Lang.$export;
+
+class Foo {
+	
+	Foo(int val, int val2) {
+		$export("addResult", val + 5);
+		$export("addResult2", val2 + 5);
+	}
+}
+
+public class DependentFields {
+
+	int i = 1;
+	int j;
+	Foo foo = new Foo(i,j);
+
+	public DependentFields() {
+	}
+
+	public static void main(String[] args) {
+		DependentFields c1 = new DependentFields();
+
+		$export("i1", "value:" + c1.i);
+		$export("j1", "value:" + c1.j);
+	}
+}


### PR DESCRIPTION
There was a problem when a not primitive field init relies on a
primitive field (please see attached unit test case).

We now guarantee that all fields are initialized the same way.