### PR TITLE
Problems when accessing elements from a tree

### DIFF
--- a/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
@@ -1033,6 +1033,10 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 	private void printDocComment(Tree tree, boolean newline) {
 		if (compilationUnit != null) {
 			TreePath treePath = getTreePath(tree);
+			if(treePath ==null) {
+				return;
+			}
+			
 			String docComment = trees().getDocComment(treePath);
 			String commentText = JSDoc.adaptDocComment(context, treePath, tree, docComment);
 
@@ -2149,7 +2153,12 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 	@Override
 	public Void visitMethod(final MethodTree methodTree, final Trees trees) {
 		ExecutableElement methodElement = toElement(methodTree);
+		//ExecutableElement methodElement = (ExecutableElement)methodTree.getClass().getField("sym").get(methodTree);
 
+		if(methodElement == null) {
+			System.out.println();
+		}
+		
 		if (context.hasAnnotationType(methodElement, JSweetConfig.ANNOTATION_ERASED)) {
 			// erased elements are ignored
 			return returnNothing();
@@ -3333,7 +3342,7 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 				}
 			}
 
-			if (util().isVarargs(varTree, getCompilationUnitForTree(varTree))) {
+			if (util().isVarargs(toElement(varTree))) {
 				print("...");
 			}
 
@@ -3343,7 +3352,7 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 				print(name);
 			}
 
-			if (!util().isVarargs(varTree, getCompilationUnitForTree(varTree))
+			if (!util().isVarargs(toElement(varTree))
 					&& (getScope().isEraseVariableTypes() || (getScope().interfaceScope
 							&& context.hasAnnotationType(varElement, JSweetConfig.ANNOTATION_OPTIONAL)))) {
 				print("?");
@@ -3972,12 +3981,12 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
 						}
 					}
 					if (methSym != null) {
-						if (context.isInvalidOverload(methSym) && !methSym.getParameters().isEmpty()
-								&& !util().hasTypeParameters(methSym) && !util().hasVarargs(methSym)
+						if (context.isInvalidOverload(methSym) 
+								&& !util().hasTypeParameters(methSym) 
 								&& getParent(MethodTree.class) != null
 								&& !getParent(MethodTree.class).getModifiers().getFlags().contains(Modifier.DEFAULT)) {
 							if (context.isInterface((TypeElement) methSym.getEnclosingElement())) {
-								removeLastChar('.');
+								removeLastChar('.')	;
 								print("['" + getOverloadMethodName(methSym) + "']");
 							} else {
 								print(getOverloadMethodName(methSym));

--- a/transpiler/src/main/java/org/jsweet/transpiler/util/AbstractTreeScanner.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/util/AbstractTreeScanner.java
@@ -30,6 +30,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
@@ -500,8 +501,14 @@ public abstract class AbstractTreeScanner extends TreePathScanner<Void, Trees> {
 	/**
 	 * @see Util#getElementForTree(Tree, CompilationUnitTree)
 	 */
+	@SuppressWarnings("unchecked")
 	protected <T extends Element> T toElement(Tree tree) {
-		return getFromTreePath(tree, treePath -> util().getElementForTreePath(treePath));
+		try {
+			return (T)tree.getClass().getField("sym").get(tree);
+		} catch (Exception e) {
+			//e.printStackTrace();
+			return getFromTreePath(tree, treePath -> util().getElementForTreePath(treePath));
+		}
 	}
 
 	/**

--- a/transpiler/src/main/java/org/jsweet/transpiler/util/Util.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/util/Util.java
@@ -1960,11 +1960,16 @@ public class Util {
 		if (tree == null) {
 			return null;
 		}
-		TreePath treePath = trees().getPath(compilationUnit, tree);
-		if (treePath == null) {
-			return null;
+		try {
+			return (T)tree.getClass().getField("sym").get(tree);
+		} catch (Exception e) {
+			TreePath treePath = trees().getPath(compilationUnit, tree);
+			if (treePath == null) {
+				return null;
+			}
+			return getElementForTreePath(treePath);
 		}
-		return getElementForTreePath(treePath);
+		
 	}
 
 	/**
@@ -2034,8 +2039,12 @@ public class Util {
 			return null;
 		}
 
-		TreePath treePath = trees().getPath(compilationUnit, tree);
-		return getTypeForTreePath(treePath);
+		try {
+			return (T) tree.getClass().getField("type").get(tree);
+		} catch (Exception e) {
+			TreePath treePath = trees().getPath(compilationUnit, tree);
+			return getTypeForTreePath(treePath);
+		}
 	}
 
 	/**

--- a/transpiler/src/test/java/org/jsweet/test/transpiler/OverloadTests.java
+++ b/transpiler/src/test/java/org/jsweet/test/transpiler/OverloadTests.java
@@ -85,6 +85,8 @@ import source.overload.WrongOverloadWithSpecialParameters;
 import source.overload.WrongOverloads;
 import source.overload.WrongOverloadsWithDefaultMethods;
 import source.overload.WrongOverloadsWithNonCoreMethod;
+import source.overload.inheritance.SubClass;
+import source.overload.inheritance.SuperClass;
 import source.overload.visitor.A1;
 import source.overload.visitor.A2;
 import source.overload.visitor.A3;
@@ -387,4 +389,11 @@ public class OverloadTests extends AbstractTest {
 				getSourceFile(ImplementationB15.class));
 	}
 
+	@Test
+	public void testWrongOverloadWithInheritance2() {
+		eval(ModuleKind.none, (logHandler, result) -> {
+			logHandler.assertNoProblems();
+		}, getSourceFile(SuperClass.class), getSourceFile(SubClass.class));
+	}
+	
 }

--- a/transpiler/src/test/java/source/overload/inheritance/SubClass.java
+++ b/transpiler/src/test/java/source/overload/inheritance/SubClass.java
@@ -1,0 +1,22 @@
+package source.overload.inheritance;
+
+public class SubClass extends SuperClass {
+
+	@Override
+
+	public boolean valuerModele() {
+
+		super.valuerModele();
+
+		System.out.println("SubClass.valuerModele()  : ");
+
+		return true;
+
+	}
+
+	public static void main(String[] args) {
+
+		new SubClass().valuerModele();
+
+	}
+}

--- a/transpiler/src/test/java/source/overload/inheritance/SuperClass.java
+++ b/transpiler/src/test/java/source/overload/inheritance/SuperClass.java
@@ -1,0 +1,30 @@
+package source.overload.inheritance;
+
+public abstract class SuperClass {
+
+
+    private String value;
+
+ 
+
+    public boolean valuerModele() {
+
+        if (value != null) {
+
+            valuerModele(value);
+
+        }
+
+        return true;
+
+    }
+
+ 
+
+    protected void valuerModele(String newValue) {
+
+        System.out.println("SuperClass : " + newValue);
+
+    }
+    
+}


### PR DESCRIPTION
This is not a PR to be merged at this point. It demonstrates issues related to accessing a model element / type from a tree. In the public API, this access can only be contextual (basically you need the compilation unit tree to get the tree path before accessing the element).

However, JSweet v2 implementation was not contextual because it used the ``sym`` and ``type`` fields in ``JCTree`` to access the elements. This leads to a complicated refactoring because in some cases (see the test of this PR),  JSweet tries to access elements of trees that don't belong to the current compilation units (typically in case of overloads, but I believe it is the case when injecting default methods too).

In  order to make the test pass, I had to introduce a reflection hack, which sucks but allows the getElement to work even when the compilation unit is not right. It would be possible to make it work, however when I see the complexity of the utility methods right now, I believe that it would be worth discussing other strategies.
