### PR TITLE
fix(sec): upgrade org.jsoup:jsoup to 1.15.3

### DIFF
--- a/candy-generator/pom.xml
+++ b/candy-generator/pom.xml
@@ -220,7 +220,7 @@
 		<dependency>
 			<groupId>org.jsoup</groupId>
 			<artifactId>jsoup</artifactId>
-			<version>1.7.2</version>
+			<version>1.15.3</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.jsoup:jsoup 1.7.2
- [CVE-2021-37714](https://www.oscs1024.com/hd/CVE-2021-37714)


### What did I do？
Upgrade org.jsoup:jsoup from 1.7.2 to 1.15.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS