### PR TITLE
test: Rename Angular.java, JQuery.java

### DIFF
--- a/transpiler/src/test/java/org/jsweet/test/transpiler/CandiesTests.java
+++ b/transpiler/src/test/java/org/jsweet/test/transpiler/CandiesTests.java
@@ -22,10 +22,10 @@ import org.jsweet.transpiler.ModuleKind;
 import org.jsweet.transpiler.SourceFile;
 import org.junit.Test;
 
-import source.candies.Angular;
+import source.candies.AngularCandy;
 import source.candies.Babylonjs;
 import source.candies.BackboneCandy;
-import source.candies.JQuery;
+import source.candies.JQueryCandy;
 import source.candies.ReactLib;
 import source.require.b.GlobalsImport;
 import source.syntax.QualifiedNames;
@@ -34,12 +34,12 @@ public class CandiesTests extends AbstractTest {
 
     @Test
     public void testAngular() {
-        transpile(TestTranspilationHandler::assertNoProblems, getSourceFile(Angular.class));
+        transpile(TestTranspilationHandler::assertNoProblems, getSourceFile(AngularCandy.class));
     }
 
     @Test
     public void testJQuery() {
-        transpile(TestTranspilationHandler::assertNoProblems, getSourceFile(JQuery.class));
+        transpile(TestTranspilationHandler::assertNoProblems, getSourceFile(JQueryCandy.class));
     }
 
     @Test

--- a/transpiler/src/test/java/source/candies/AngularCandy.java
+++ b/transpiler/src/test/java/source/candies/AngularCandy.java
@@ -26,7 +26,7 @@ import def.angularjs.ng.route.IRoute;
 import def.angularjs.ng.route.IRouteProvider;
 import def.js.Array;
 
-public class Angular {
+public class AngularCandy {
 
 	public static void main(String[] args) {
 

--- a/transpiler/src/test/java/source/candies/JQueryCandy.java
+++ b/transpiler/src/test/java/source/candies/JQueryCandy.java
@@ -23,7 +23,7 @@ import def.jquery.JQueryXHR;
 import static jsweet.util.Lang.function;
 
 @SuppressWarnings("all")
-public class JQuery {
+public class JQueryCandy {
 
 	public static void main(String[] args) {
 		$("p").append(" (end)");


### PR DESCRIPTION
Tests would fail because "angular.ts" and "jQuery.ts" would already be included with a differenent case.

Rename Angular to AngularCandy, JQuery to JQueryCandy, which is also in line with "BackboneCandy".