### PR TITLE
test: Fix tests that spawn new processes

### DIFF
--- a/transpiler/src/test/java/org/jsweet/test/transpiler/TranspilerTests.java
+++ b/transpiler/src/test/java/org/jsweet/test/transpiler/TranspilerTests.java
@@ -93,6 +93,10 @@ public class TranspilerTests extends AbstractTest {
         process = ProcessUtil.runCommand("java", line -> {
             System.out.println(line);
         }, null, "-cp", TranspilerTestRunner.getTestClassPath(), //
+                "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
                 JSweetCommandLineLauncher.class.getName(), //
                 "--tsout", outDir.getPath(), //
                 "--targetVersion", "ES6", //
@@ -118,6 +122,10 @@ public class TranspilerTests extends AbstractTest {
         process = ProcessUtil.runCommand("java", line -> {
             System.out.println(line);
         }, null, "-cp", TranspilerTestRunner.getTestClassPath(), //
+                "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
                 JSweetCommandLineLauncher.class.getName(), //
                 "--tsout", outDir.getPath(), //
                 "--jsout", outDir.getPath(), //
@@ -143,6 +151,10 @@ public class TranspilerTests extends AbstractTest {
         process = ProcessUtil.runCommand("java", line -> {
             System.out.println(line);
         }, null, "-cp", TranspilerTestRunner.getTestClassPath(), //
+                "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
                 JSweetCommandLineLauncher.class.getName(), //
                 "--tsout", outDir.getPath(), //
                 "--jsout", outDir.getPath(), //
@@ -161,6 +173,10 @@ public class TranspilerTests extends AbstractTest {
         process = ProcessUtil.runCommand("java", line -> {
             System.out.println(line);
         }, null, "-cp", TranspilerTestRunner.getTestClassPath(), //
+                "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
                 JSweetCommandLineLauncher.class.getName(), //
                 "--tsout", outDir.getPath(), //
                 "--jsout", outDir.getPath(), //
@@ -178,6 +194,10 @@ public class TranspilerTests extends AbstractTest {
         process = ProcessUtil.runCommand("java", line -> {
             System.out.println(line);
         }, null, "-cp", TranspilerTestRunner.getTestClassPath(), //
+                "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
                 JSweetCommandLineLauncher.class.getName(), //
                 "--tsout", outDir.getPath(), //
                 "--jsout", outDir.getPath(), //
@@ -204,6 +224,10 @@ public class TranspilerTests extends AbstractTest {
         process = ProcessUtil.runCommand("java", line -> {
             System.out.println(line);
         }, null, "-cp", TranspilerTestRunner.getTestClassPath(), //
+                "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
                 JSweetCommandLineLauncher.class.getName(), //
                 "--tsout", outDir.getPath(), //
                 "--jsout", outDir.getPath(), //
@@ -228,6 +252,10 @@ public class TranspilerTests extends AbstractTest {
         process = ProcessUtil.runCommand("java", line -> {
             System.out.println(line);
         }, null, "-cp", TranspilerTestRunner.getTestClassPath(), //
+                "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+                "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
                 JSweetCommandLineLauncher.class.getName(), //
                 "--tsout", outDir.getPath(), //
                 "--jsout", outDir.getPath(), //


### PR DESCRIPTION
Some tests try to spawn a new Java process for the JSweetCommandLineLauncher.

These tests fail with new Java versions >= 16.

Specify --add-opens=jdk.compiler/... statements to allow our code to access the Java Compiler packages under com.sun.tools.javac...