### PR TITLE
Add /opt/local/bin to the Eclipse path workaround

### DIFF
--- a/transpiler/src/main/java/org/jsweet/transpiler/util/ProcessUtil.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/util/ProcessUtil.java
@@ -60,6 +60,10 @@ public class ProcessUtil {
                 addExtraPath("/usr/local/bin");
                 ProcessUtil.NODE_COMMAND = "/usr/local/bin/node";
                 ProcessUtil.NPM_COMMAND = "/usr/local/bin/npm";
+            } else if (!System.getenv("PATH").contains("/opt/local/bin") && new File("/opt/local/bin/node").exists()) {
+                addExtraPath("/opt/local/bin");
+                ProcessUtil.NODE_COMMAND = "/opt/local/bin/node";
+                ProcessUtil.NPM_COMMAND = "/opt/local/bin/npm";
             }
             initialized = true;
         }


### PR DESCRIPTION
In some environments, "node" may not be on the PATH.

Add another path that is commonly supported, /opt/local/bin.

Note that we cannot add /opt/homebrew/bin since there's a dependency that would need changing as well (typescript.java).

For the time being, it is encouraged to add a symbolic link from /opt/homebrew/bin/node to /opt/local/bin/node (and npm) if that's necessary.