### PR TITLE
Add support @TsNoCheck annotation, adds "// @ts-nocheck" to TypeScript

### DIFF
--- a/core-lib/es5/src/main/java/jsweet/lang/TsNoCheck.java
+++ b/core-lib/es5/src/main/java/jsweet/lang/TsNoCheck.java
@@ -1,0 +1,35 @@
+/* 
+ * JSweet - http://www.jsweet.org
+ * Copyright (C) 2015 CINCHEO SAS <renaud.pawlak@cincheo.fr>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jsweet.lang;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation tells the transpiler to emit {@code // @ts-nocheck} at the beginning of
+ * the file.
+ * 
+ * @author Christian Kohlschütter
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ ElementType.TYPE })
+@Documented
+public @interface TsNoCheck {
+}

--- a/core-lib/es6/src/main/java/jsweet/lang/TsNoCheck.java
+++ b/core-lib/es6/src/main/java/jsweet/lang/TsNoCheck.java
@@ -1,0 +1,35 @@
+/* 
+ * JSweet - http://www.jsweet.org
+ * Copyright (C) 2015 CINCHEO SAS <renaud.pawlak@cincheo.fr>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jsweet.lang;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation tells the transpiler to emit {@code // @ts-nocheck} at the beginning of
+ * the file.
+ * 
+ * @author Christian Kohlschütter
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ ElementType.TYPE })
+@Documented
+public @interface TsNoCheck {
+}

--- a/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
+++ b/transpiler/src/main/java/org/jsweet/transpiler/Java2TypeScriptTranslator.java
@@ -759,6 +759,22 @@ public class Java2TypeScriptTranslator extends AbstractTreePrinter {
                     packageElement, getCompilationUnit());
         }
 
+        // TypeScript access a line marked "// @ts-nocheck" at the beginning of the file
+        // to suppress certain warnings. Java won't allow us to annotate the "package" statement,
+        // so let's check all types.
+        checkTsNoCheck : for (Tree def : compilationUnit.getTypeDecls()) {
+          if (def instanceof ClassTree) {
+            for (AnnotationTree at : ((ClassTree)def).getModifiers().getAnnotations()) {
+              // NOTE This supports TsNoCheck being an annotation in any package
+              String typeStr = at.getAnnotationType().toString();
+              if ("TsNoCheck".equals(typeStr) || typeStr.endsWith(".TsNoCheck")) {
+                print("// @ts-nocheck\n");
+                break checkTsNoCheck;
+              }
+            }
+          }
+        }
+
         PackageElement rootPackage = context.getFirstEnclosingRootPackage(packageElement);
         if (rootPackage != null) {
             if (!checkRootPackageParent(compilationUnit, rootPackage,

--- a/transpiler/src/test/java/source/nativestructures/Numbers.java
+++ b/transpiler/src/test/java/source/nativestructures/Numbers.java
@@ -4,7 +4,11 @@ import static jsweet.util.Lang.$export;
 import static def.js.Globals.isNaN;
 
 import def.js.Array;
+import jsweet.lang.TsNoCheck;
 
+//without this annotation, TypeScript would complain about the asserts in line 44/45
+// ("[ts] This condition will always return 'true'")
+@TsNoCheck
 public class Numbers {
 
 	static Array<String> trace = new Array<>();


### PR DESCRIPTION
Typescript would complain about certain errors in the generated file. In some newer versions of TypeScript, an assert that is always true would not be permitted.

We currently have two such asserts in our tests, which prevents us from upgrading the TypeScript version.

Add support for a Java @TsNoCheck annotation, which controls the inclusion of the corresponding TypeScript comment. While there is no mandatory package for the annotation, add it to jsweet.lang in core-lib.

Fix tests to use the new annotation.