### PR TITLE
candy-generator: Generate parser by default

### DIFF
--- a/candy-generator/pom.xml
+++ b/candy-generator/pom.xml
@@ -153,6 +153,9 @@
 	<profiles>
 		<profile>
 			<id>genparser</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
 			<build>
 				<plugins>
 					<plugin>


### PR DESCRIPTION
The parser is currently generated only when a certain build profile is enabled.

This is hard to figure out, and building time is negligible.

Enable building the parser by default (enable the profile by default).

Should building fail on CI, then the build.xml script should be fixed instead.