### PR TITLE
test: Change erased type in AnnotationTest

### DIFF
--- a/transpiler/src/test/java/source/extension/AnnotationTest.java
+++ b/transpiler/src/test/java/source/extension/AnnotationTest.java
@@ -3,6 +3,7 @@ package source.extension;
 import java.util.EventObject;
 import java.util.List;
 import java.util.Map;
+import java.util.ServiceLoader;
 
 import jsweet.lang.Name;
 
@@ -27,7 +28,7 @@ public class AnnotationTest extends Superclass {
 	
 	public void toBeErased() {
 		// this will not be transpiled because the method will be erased
-		javax.accessibility.AccessibilityProvider foo = null;
+		ServiceLoader<?> foo = null;
 	}
 
 	public void m() {


### PR DESCRIPTION
Just to test a type erasure, we currently reference javax.accessibility.AccessibilityProvider, which is in the "java.deskop" module.

If we were to modularize jsweet, we would have to "requires java.desktop" just for this (or Eclipse would not be able to run unit tests).

Moreover, that module may not exist in all JVM environments.

Change to a similar class in "java.base", ServiceLoader, and adjust module-info.java.txt accordingly.